### PR TITLE
Quick fix to support some mongo query operators and regexp on .find()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 scratch.js
 mongo.json
 mongo.js
+node_modules/*

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -40,7 +40,25 @@ module.exports = function Collection(db, state) {
         var documents = state.documents;
         if(!documents) return opts.callback(null, []);
 
-        var docs = _.where(documents, opts.query);
+        var docs;
+        if(typeof opts.query == 'object'){
+          docs = []
+          _.find(documents, function(item){
+            var match = true;
+            
+            Object.keys(opts.query).forEach(function(key){
+              if(opts.query[key] instanceof RegExp){
+                if(!opts.query[key].exec(item[key])) match = false;
+              } else {
+                if(opts.query[key] != item[key]) match = false;
+              }
+            });
+            
+            if(match) docs.push(item);
+          });
+        } else {
+          docs = _.where(documents, opts.query);
+        }
         docs = _.cloneDeep(docs, cloneObjectIDs);
         if(opts.fields) {
           var props = Object.keys(opts.fields);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -54,11 +54,11 @@ module.exports = function Collection(db, state) {
                 //Iterate through the keys of the object. If its $gte, $lt, etc, check it against the key
                 Object.keys(opts.query[key]).forEach(function(check){
                   
-                   if(!(check == "$gt" && opts.query[key][check] > item[key])) match = false;
-                   else if(!(check == "$gte" && opts.query[key][check] >= item[key])) match = false;
-                   else if(!(check == "$lt" && opts.query[key][check] < item[key])) match = false;
-                   else if(!(check == "$lte" && opts.query[key][check] <= item[key])) match = false;
-                   else if(!(check == "$eq" && opts.query[key][check] == item[key])) match = false;
+                   if(check == "$gt" &&  !(opts.query[key][check] > item[key])) match = false;
+                   else if(check == "$gte" && !(opts.query[key][check] >= item[key])) match = false;
+                   else if(check == "$lt" && !(opts.query[key][check] < item[key])) match = false;
+                   else if(check == "$lte" && !(opts.query[key][check] <= item[key])) match = false;
+                   else if(check == "$eq" && !(opts.query[key][check] == item[key])) match = false;
                    else if(check == "$neq" && opts.query[key][check] == item[key]) match = false;
                    else if(check == "$in" && opts.query[key][check].indexOf(item[key]) == -1) match = false;
                    else if(check == "$nin" && opts.query[key][check].indexOf(item[key]) != -1) match = false;

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -49,6 +49,22 @@ module.exports = function Collection(db, state) {
             Object.keys(opts.query).forEach(function(key){
               if(opts.query[key] instanceof RegExp){
                 if(!opts.query[key].exec(item[key])) match = false;
+              } else if(typeof opts.query[key] == 'object'){
+                
+                //Iterate through the keys of the object. If its $gte, $lt, etc, check it against the key
+                Object.keys(opts.query[key]).forEach(function(check){
+                  
+                   if(!(check == "$gt" && opts.query[key][check] > item[key])) match = false;
+                   else if(!(check == "$gte" && opts.query[key][check] >= item[key])) match = false;
+                   else if(!(check == "$lt" && opts.query[key][check] < item[key])) match = false;
+                   else if(!(check == "$lte" && opts.query[key][check] <= item[key])) match = false;
+                   else if(!(check == "$eq" && opts.query[key][check] == item[key])) match = false;
+                   else if(check == "$neq" && opts.query[key][check] == item[key]) match = false;
+                   else if(check == "$in" && opts.query[key][check].indexOf(item[key]) == -1) match = false;
+                   else if(check == "$nin" && opts.query[key][check].indexOf(item[key]) != -1) match = false;
+                  
+                });
+                
               } else {
                 if(opts.query[key] != item[key]) match = false;
               }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -54,10 +54,10 @@ module.exports = function Collection(db, state) {
                 //Iterate through the keys of the object. If its $gte, $lt, etc, check it against the key
                 Object.keys(opts.query[key]).forEach(function(check){
                   
-                   if(check == "$gt" &&  !(opts.query[key][check] > item[key])) match = false;
-                   else if(check == "$gte" && !(opts.query[key][check] >= item[key])) match = false;
-                   else if(check == "$lt" && !(opts.query[key][check] < item[key])) match = false;
-                   else if(check == "$lte" && !(opts.query[key][check] <= item[key])) match = false;
+                   if(check == "$gt" &&  !(opts.query[key][check] < item[key])) match = false;
+                   else if(check == "$gte" && !(opts.query[key][check] <= item[key])) match = false;
+                   else if(check == "$lt" && !(opts.query[key][check] > item[key])) match = false;
+                   else if(check == "$lte" && !(opts.query[key][check] >= item[key])) match = false;
                    else if(check == "$eq" && !(opts.query[key][check] == item[key])) match = false;
                    else if(check == "$neq" && opts.query[key][check] == item[key]) match = false;
                    else if(check == "$in" && opts.query[key][check].indexOf(item[key]) == -1) match = false;


### PR DESCRIPTION
This is a quick fix to add support for regexp, and operators such as $gte in mongo. This is an initial draft I needed to do for a project and thought I'd share to see if you thought this was a good direction.

Pull request does not need to be accepted, this can just be for review as well.

Features not extended to .findOne() yet.