### PR TITLE
add aliases for insertOne and insertMany to support node-mongodb-native/2.2 col.insert() deprecation

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -240,6 +240,8 @@ module.exports = function Collection(db, state) {
       return state;
     }
   };
+  interface.insertOne = interface.insert;
+  interface.insertMany = interface.insert;
   interface.removeOne = interface.deleteOne;
   interface.removeMany = interface.deleteMany;
   interface.dropAllIndexes = interface.dropIndexes;

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -65,6 +65,7 @@ var Cursor = module.exports = function(documents, opts) {
       if(state !== Cursor.INIT)
         throw new Error('MongoError: Cursor is closed');
       opts.limit = n;
+      return this;
     },
 
     next: function (callback) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "William Kapke",
   "name": "mongo-mock",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Let's pretend we have a real MongoDB",
   "main": "mongo-mock.js",
   "scripts": {


### PR DESCRIPTION
Please see deprecation notice on http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#insert