### PR TITLE
Fix: cursor.skip wasn't returning 'this' so wasn't chainable

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -89,6 +89,7 @@ var Cursor = module.exports = function(documents, opts) {
       if(state !== Cursor.INIT)
         throw new Error('MongoError: Cursor is closed');
       opts.skip = n;
+      return this;
     },
 
     toArray: function (callback) {
@@ -121,20 +122,3 @@ function NotImplemented(){
 function cloneObjectIDs(value) {
   return value instanceof ObjectId? ObjectId(value) : undefined;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -225,4 +225,42 @@ describe('mock tests', function () {
       });
     });
   });
+
+  describe('cursors', function() {
+    it('should return a count of found items', function (done) {
+      var crsr = collection.find({});
+      crsr.should.have.property('count');
+      crsr.count(function(err, cnt) {
+        cnt.should.equal(6);
+        done();
+      });
+    });
+
+    it('should skip 1 item', function (done) {
+      var crsr = collection.find({});
+      crsr.should.have.property('skip');
+      crsr.skip(1).toArray(function(err, res) {
+        res.length.should.equal(5);
+        done();
+      });
+    });
+
+    it('should limit to 3 items', function (done) {
+      var crsr = collection.find({});
+      crsr.should.have.property('limit');
+      crsr.limit(3).toArray(function(err, res) {
+        res.length.should.equal(3);
+        done();
+      });
+    });
+
+    it('should skip 1 item, limit to 3 items', function (done) {
+      var crsr = collection.find({});
+      crsr.should.have.property('limit');
+      crsr.skip(1).limit(3).toArray(function(err, res) {
+        res.length.should.equal(3);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
I couldn't seem to get `collection.find({}).skip(10)` to work. Looks like Cursor.skip wasn't returning `this` so the chain was breaking. Added some tests to verify.
