### PR TITLE
Fix: Cursor.count was applying skip/limit by default

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -40,7 +40,10 @@ module.exports = function Collection(db, state) {
 
     aggregate: NotImplemented,
     bulkWrite: NotImplemented,
-    count: NotImplemented,
+    count: function() {
+      var opts = find_options(arguments);
+      return this.find(opts.query || {}, opts).count(opts.callback);
+    },
     createIndex: function (keys, options, callback) {
       return db.createIndex(name, keys, options, callback);
     },

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -18,9 +18,6 @@ var Cursor = module.exports = function(documents, opts) {
 
     state = Cursor.OPEN;
     docs = sift(opts.query, documents);
-    if (applySkipLimit) {
-      docs = docs.slice(opts.skip||0, opts.skip+(opts.limit||docs.length));
-    }
     if (opts.sort) {
       docs = docs.sort(function(a,b) {
         retVal = 0;
@@ -37,7 +34,9 @@ var Cursor = module.exports = function(documents, opts) {
         return retVal;
       });
     }
-    docs = docs.slice(opts.skip||0, opts.skip+(opts.limit||docs.length));
+    if (applySkipLimit) {
+      docs = docs.slice(opts.skip||0, opts.skip+(opts.limit||docs.length));
+    }
     docs = _.cloneDeep(docs, cloneObjectIDs);
 
     if(docs.length && opts.fields) {

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -12,12 +12,9 @@ var Cursor = module.exports = function(documents, opts) {
   var state = Cursor.INIT;
   if(!documents) documents = [];
 
-  var docs;
   function getDocs(applySkipLimit) {
-    if(docs) return docs;
-
     state = Cursor.OPEN;
-    docs = sift(opts.query, documents);
+    var docs = sift(opts.query, documents);
     if (opts.sort) {
       docs = docs.sort(function(a,b) {
         retVal = 0;
@@ -102,6 +99,10 @@ var Cursor = module.exports = function(documents, opts) {
 
     rewind: function () {
       i = 0;
+    },
+
+    size: function(callback) {
+      return this.count(true, callback);
     },
 
     skip: function (n) {

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -13,12 +13,14 @@ var Cursor = module.exports = function(documents, opts) {
   if(!documents) documents = [];
 
   var docs;
-  function getDocs() {
+  function getDocs(applySkipLimit) {
     if(docs) return docs;
 
     state = Cursor.OPEN;
     docs = sift(opts.query, documents);
-    docs = docs.slice(opts.skip||0, opts.skip+(opts.limit||docs.length));
+    if (applySkipLimit) {
+      docs = docs.slice(opts.skip||0, opts.skip+(opts.limit||docs.length));
+    }
     docs = _.cloneDeep(docs, cloneObjectIDs);
 
     if(docs.length && opts.fields) {
@@ -49,13 +51,14 @@ var Cursor = module.exports = function(documents, opts) {
       if(callback) return callback(null, interface);
     },
 
-    count: function (callback) {
+    count: function (applySkipLimit, callback) {
       callback = arguments[arguments.length-1];
+      applySkipLimit = (applySkipLimit === callback) ? false : applySkipLimit;
       if(typeof callback !== 'function')
-        return Promise.resolve(getDocs().length);
+        return Promise.resolve(getDocs(applySkipLimit).length);
 
       asyncish(function () {
-        callback(null, getDocs().length)
+        callback(null, getDocs(applySkipLimit).length)
       });
     },
 
@@ -69,7 +72,7 @@ var Cursor = module.exports = function(documents, opts) {
     },
 
     next: function (callback) {
-      var docs = getDocs();
+      var docs = getDocs(true);
       var limit = Math.min(opts.limit || Number.MAX_VALUE, docs.length);
       var next_idx = i<limit? i++ : i;
       var doc = docs[next_idx] || null;
@@ -97,7 +100,7 @@ var Cursor = module.exports = function(documents, opts) {
 
       function done() {
         interface.rewind();
-        return getDocs();
+        return getDocs(true);
       }
 
       if(!callback)

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -291,5 +291,21 @@ describe('mock tests', function () {
         done();
       });
     });
+
+    it('should count all items regardless of skip/limit', function (done) {
+      var crsr = collection.find({});
+      crsr.skip(1).limit(3).count(function(err, cnt) {
+        cnt.should.equal(6);
+        done();
+      });
+    });
+
+    it('should count only skip/limit results', function (done) {
+      var crsr = collection.find({});
+      crsr.skip(1).limit(3).count(true, function(err, cnt) {
+        cnt.should.equal(3);
+        done();
+      });
+    });
   });
 });

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -254,6 +254,19 @@ describe('mock tests', function () {
         });
       });
     });
+    it('should count the number of items in the collection', function(done) {
+      collection.should.have.property('count');
+      collection.count({}, function(err, cnt) {
+        if (err) done(err);
+        cnt.should.equal(6);
+
+        collection.count({ test:333 }, function(err, singleCnt) {
+          if (err) done(err);
+          singleCnt.should.equal(1);
+          done();
+        });
+      });
+    });
   });
 
   describe('cursors', function() {

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -300,7 +300,7 @@ describe('mock tests', function () {
         done();
       });
     });
-    
+
     it('should count only skip/limit results', function (done) {
       var crsr = collection.find({});
       crsr.skip(1).limit(3).count(true, function(err, cnt) {
@@ -316,7 +316,7 @@ describe('mock tests', function () {
         done();
       });
     });
-    
+
     it('should sort results by `test` ascending', function (done) {
       var crsr = collection.find({});
       crsr.should.have.property('sort');
@@ -327,7 +327,7 @@ describe('mock tests', function () {
         done();
       });
     });
-        
+
     it('should sort results by `test` descending', function (done) {
       var crsr = collection.find({});
       crsr.should.have.property('sort');

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -307,5 +307,13 @@ describe('mock tests', function () {
         done();
       });
     });
+
+    it('should count only skip/limit results but return actual count if less than limit', function (done) {
+      var crsr = collection.find({});
+      crsr.skip(4).limit(3).count(true, function(err, cnt) {
+        cnt.should.equal(2);
+        done();
+      });
+    });
   });
 });

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -309,10 +309,29 @@ describe('mock tests', function () {
       });
     });
 
+    it('should toggle count applySkipLimit and not', function (done) {
+      var crsr = collection.find({}).skip(1).limit(3);
+      crsr.count(true, function(err, cnt) {
+        cnt.should.equal(3);
+        crsr.count(function(err, cnt) {
+          cnt.should.equal(6);
+          done();
+        });
+      });
+    });
+
     it('should count only skip/limit results but return actual count if less than limit', function (done) {
       var crsr = collection.find({});
       crsr.skip(4).limit(3).count(true, function(err, cnt) {
         cnt.should.equal(2);
+        done();
+      });
+    });
+
+    it('should count only skip/limit results for size', function (done) {
+      var crsr = collection.find({});
+      crsr.skip(2).limit(3).size(function(err, cnt) {
+        cnt.should.equal(3);
         done();
       });
     });


### PR DESCRIPTION
(Ok, it's late and I could be crazy at this point)
It seems Cursor.count was only returning the count with skip/limit applied.
According to the mongo docs: https://docs.mongodb.com/manual/reference/method/cursor.count/
I _believe_ it should return the count of all results unless you run `cursor.count(true)` (at least that's how the db seems to be working for me, I'm kinda new to Mongo)

This change was a little less straight forward but seems to work and all tests pass! It just feels a little less elegant so I'm open to achieving this a different way.

*NOTE*: This will totally break tests for people expecting the current (incorrect?) automatic application of skip/limit for count