### PR TITLE
expose ObjectId just like the native driver does

### DIFF
--- a/mongo-mock.js
+++ b/mongo-mock.js
@@ -8,7 +8,8 @@ module.exports = {
     setTimeout(callback, Math.random()*(delay));
   },
   find_options: find_options,
-  get MongoClient() { return require('./lib/mongo_client.js') }
+  get MongoClient() { return require('./lib/mongo_client.js') },
+  get ObjectId() { return require('bson-objectid') }
 };
 
 var noop = Boolean;

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -1,9 +1,9 @@
 var should = require('should');
-var ObjectId = require('bson-objectid');
 var _ = require('lodash');
-var id = ObjectId();
 var mongo = require('../');
 var MongoClient = mongo.MongoClient;
+var ObjectId = mongo.ObjectId;
+var id = ObjectId();
 MongoClient.persist = "mongo.js";
 
 describe('mock tests', function () {


### PR DESCRIPTION
I'm using the ObjectId exposed by the native driver so I want this in the mock driver too ;)
Implements: `require('mongo-mock').ObjectId` just like in here: 
http://mongodb.github.io/node-mongodb-native/2.2/api/ObjectID.html