### PR TITLE
add insertedId(s) to insert response. Fixes #23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ scratch.js
 mongo.json
 mongo.js
 node_modules
+yarn.lock

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -169,7 +169,7 @@ module.exports = function Collection(db, state) {
         state.persist();
         callback(null, {
           insertedIds: insertedIds,
-          insertedCount: insertedIds.length,
+          insertedCount: docs.length,
           result: {ok:1,n:docs.length},
           connection: {},
           ops: _.cloneDeep(docs, cloneObjectIDs)
@@ -189,7 +189,7 @@ module.exports = function Collection(db, state) {
         if(e) return callback(e)
         callback(null, {
           insertedId: r.insertedIds[0],
-          insertedCount: r.insertedCount,
+          insertedCount: r.result.n,
           result: r.result,
           connection: r.connection,
           ops: r.ops

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -168,8 +168,8 @@ module.exports = function Collection(db, state) {
 
         state.persist();
         callback(null, {
-          insertedId: insertedIds[0],// used for (deprecated) insertOne's result
           insertedIds: insertedIds,
+          insertedCount: insertedIds.length,
           result: {ok:1,n:docs.length},
           connection: {},
           ops: _.cloneDeep(docs, cloneObjectIDs)
@@ -182,7 +182,26 @@ module.exports = function Collection(db, state) {
       }
     },
     get insertMany() { return this.insert; },
-    get insertOne() { return this.insert; },
+    insertOne: function(doc, options, callback) {
+      callback = arguments[arguments.length-1];
+
+      this.insert([doc], options, function (e, r) {
+        if(e) return callback(e)
+        callback(null, {
+          insertedId: r.insertedIds[0],
+          insertedCount: r.insertedCount,
+          result: r.result,
+          connection: r.connection,
+          ops: r.ops
+        })
+      })
+
+      if(typeof callback!=='function') {
+        return new Promise(function (resolve,reject) {
+          callback = function (e, r) { e? reject(e) : resolve(r) };
+        })
+      }
+    },
     isCapped: NotImplemented,
     listIndexes: NotImplemented,
     mapReduce: NotImplemented,

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -149,6 +149,7 @@ module.exports = function Collection(db, state) {
       // are committed until the first error. No information
       // about the successful inserts are return :/
       asyncish(function () {
+        var insertedIds = [];
         for (var i = 0; i < docs.length; i++) {
           var doc = docs[i];
           if(!doc._id) doc._id = pk();
@@ -161,10 +162,14 @@ module.exports = function Collection(db, state) {
 
           if(!state.documents) state.documents = [doc];
           else state.documents.push(doc);
+
+          insertedIds.push(doc._id)
         }
 
         state.persist();
         callback(null, {
+          insertedId: insertedIds[0],// used for (deprecated) insertOne's result
+          insertedIds: insertedIds,
           result: {ok:1,n:docs.length},
           connection: {},
           ops: _.cloneDeep(docs, cloneObjectIDs)

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -77,6 +77,8 @@ describe('mock tests', function () {
         (!!result.ops[0]._id).should.be.true;
         result.ops[0]._id.toString().should.have.length(24);
         result.ops[0].should.have.property('test', 123);
+        result.should.have.property('insertedId');
+        result.should.have.property('insertedIds');
         done();
       });
     });

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -78,7 +78,7 @@ describe('mock tests', function () {
         result.ops[0]._id.toString().should.have.length(24);
         result.ops[0].should.have.property('test', 123);
         result.should.have.property('insertedId');
-        result.should.have.property('insertedIds');
+        result.should.have.property('insertedCount');
         done();
       });
     });


### PR DESCRIPTION
@detrohutt I was reviewing your pull #23 and it looks like it main change is adding `insertedId` & `insertedIds` to the result. (LMK if I missed something else)

I pulled your changes for that but kept reusing the `insert` function. For `insertOne`, which I see is now deprecated, I just added the singular `insertedId` to the result. So- yeah, it will show up in the multi insert results- but I'm thinking it won't harm anything and keeps it simple.

PTAL. Thanks!