### PR TITLE
Adds absent field when using $push on updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 scratch.js
 mongo.json
 mongo.js

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -288,6 +288,11 @@ module.exports = function Collection(db, state) {
             if (_.has(data, '$push')) {
               _.forEach(data.$push, function (pushValue, key) {
                 var originalArray = _.get(original, key);
+                // If the field is absent in the document to update, $push adds the array field: https://docs.mongodb.com/manual/reference/operator/update/push/
+                if (!originalArray){
+                  _.set(original, key, []);
+                  originalArray = _.get(original, key);
+                }
                 var values = pushValue.$each;
                 var slice = pushValue.$slice;
                 debug('%s.%s $push: key: %s, $each:%s, $slice: %s', name, action, key, values, slice);

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -472,6 +472,18 @@ describe('mock tests', function () {
         });
       });
     });
+    it('should push item into array that does not yet exist on the doc', function (done) {
+      collection.update({test:333}, { $push:{ newPushTest: {$each: [ 2 ]} }} ,function (err, result) {
+        if (err) done(err);
+        result.n.should.equal(1);
+        collection.findOne({test: 333}, function (err, doc) {
+          if (err) done(err);
+          doc.newPushTest.should.have.length(1);
+          doc.newPushTest.should.containEql(2);
+          done();
+        });
+      });
+    });
     it('should push item into array + $slice', function (done) {
       collection.update({test:333}, { $set: {pushTest: []}}, function (err, result) {
         if (err) done(err);


### PR DESCRIPTION
If the field is absent in the document to update, $push adds the array field with the value as its element.

https://docs.mongodb.com/manual/reference/operator/update/push/