### PR TITLE
Extended upsert functionality

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -252,6 +252,7 @@ module.exports = function Collection(db, state) {
         if(!Array.isArray(docs)) docs = [docs];
         debug('%s.%s %j', name, action, docs);
 
+
         if(!docs.length && options.upsert) {
           var cloned = _.cloneDeep(data.$setOnInsert || data.$set || data, cloneObjectIDs);
           cloned._id = selector._id || pk();
@@ -266,59 +267,58 @@ module.exports = function Collection(db, state) {
           if(!state.documents) state.documents = [cloned];
           else state.documents.push(cloned);
 
-          result.n = 1;
           result.ops = [cloned];
+          docs.push(cloned);
         }
-        else {
-          debug('%s.%s checking for index conflicts', name, action);
-          for (var i = 0; i < docs.length; i++) {
-            var original = docs[i];
-            if (_.has(data, '$addToSet')) {
-              _.forEach(data.$addToSet, function (values, key) {
-                original[key] = addToSet(original[key] || [], values);
-              });
-              delete data.$addToSet;
-            }
-            if (_.has(data, '$inc')) {
-              _.forEach(data.$inc, function (incValue, key) {
-                _.set(original, key, _.get(original, key, 0) + incValue);
-              });
-              delete data.$inc;
-            }
-            if (_.has(data, '$push')) {
-              _.forEach(data.$push, function (pushValue, key) {
-                var originalArray = _.get(original, key);
-                // If the field is absent in the document to update, $push adds the array field: https://docs.mongodb.com/manual/reference/operator/update/push/
-                if (!originalArray){
-                  _.set(original, key, []);
-                  originalArray = _.get(original, key);
-                }
-                var values = pushValue.$each;
-                var slice = pushValue.$slice;
-                debug('%s.%s $push: key: %s, $each:%s, $slice: %s', name, action, key, values, slice);
-                if (values) {
-                  _.forEach(values, function(val) {
-                    originalArray.push(val);
-                    if (slice) {
-                      _.set(original, key, originalArray.slice(slice));
-                    }
-                  });
-                }
-              });  
-            }
-            if (typeof data.$set !== 'undefined') {
-              data.$set = mapDotNotationToJson(data.$set);
-            }
-            var updated = _.extend({}, original, data.$set || {});
-            var conflict = state.findConflict(updated, original);
-            if(conflict) {
-              debug('conflict found %j', conflict);
-              return callback(conflict);
-            }
-            _.merge(original, data.$set || {});
+
+        debug('%s.%s checking for index conflicts', name, action);
+        for (var i = 0; i < docs.length; i++) {
+          var original = docs[i];
+          if (_.has(data, '$addToSet')) {
+            _.forEach(data.$addToSet, function (values, key) {
+              original[key] = addToSet(original[key] || [], values);
+            });
+            delete data.$addToSet;
           }
-          result.n = docs.length;
+          if (_.has(data, '$inc')) {
+            _.forEach(data.$inc, function (incValue, key) {
+              _.set(original, key, _.get(original, key, 0) + incValue);
+            });
+            delete data.$inc;
+          }
+          if (_.has(data, '$push')) {
+            _.forEach(data.$push, function (pushValue, key) {
+              var originalArray = _.get(original, key);
+              // If the field is absent in the document to update, $push adds the array field: https://docs.mongodb.com/manual/reference/operator/update/push/
+              if (!originalArray){
+                _.set(original, key, []);
+                originalArray = _.get(original, key);
+              }
+              var values = pushValue.$each;
+              var slice = pushValue.$slice;
+              debug('%s.%s $push: key: %s, $each:%s, $slice: %s', name, action, key, values, slice);
+              if (values) {
+                _.forEach(values, function(val) {
+                  originalArray.push(val);
+                  if (slice) {
+                    _.set(original, key, originalArray.slice(slice));
+                  }
+                });
+              }
+            });
+          }
+          if (typeof data.$set !== 'undefined') {
+            data.$set = mapDotNotationToJson(data.$set);
+          }
+          var updated = _.extend({}, original, data.$set || {});
+          var conflict = state.findConflict(updated, original);
+          if(conflict) {
+            debug('conflict found %j', conflict);
+            return callback(conflict);
+          }
+          _.merge(original, data.$set || {});
         }
+        result.n = docs.length;
 
         state.persist();
         callback(null, result);


### PR DESCRIPTION
When doing an upsert, $push, $inc, $addToSet are now being handled.  

Also, discovered a potential issue demonstrated with the test: 'should sort results by `test` ascending'. When sorting, if the sort by field is undefined sorting seems incorrect.  Underlying sort issue not fixed here.  Just altered test to use $exists instead.