### PR TITLE
Corrected getDocs()'s fields behavior (partially)

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -37,14 +37,11 @@ var Cursor = module.exports = function(documents, opts) {
     docs = _.cloneDeep(docs, cloneObjectIDs);
 
     if(docs.length && opts.fields) {
-      var props = Object.keys(opts.fields);
-      var type = opts.fields[props[0]];
-      type = type === 1 ? "pick" : type === -1 ? "omit" : undefined;
-      if (docs.length && type) {
-        docs = docs.map(function (doc) {
-          return _[type](doc, props);//only supports simple projections. PRs welcome! :)
-        });
-      }
+      // The MongoDB does always return _id, if it wasn't opt out
+      opts.fields._id = opts.fields._id === 0 ? 0 : 1;
+      var validFields = _.pick(opts.fields, function (value) { return !!value; });
+      var props = Object.keys(validFields);
+      docs = docs.map(function (doc) { return _.pick(doc, props); }); //only supports simple projections. PRs welcome! :)
     }
     return docs;
   }

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -36,7 +36,7 @@ var Cursor = module.exports = function(documents, opts) {
     }
     docs = _.cloneDeep(docs, cloneObjectIDs);
 
-    if(docs.length && opts.fields) {
+    if(docs.length && !_.isEmpty(opts.fields)) {
       // The MongoDB does always return _id, if it wasn't opt out
       opts.fields._id = opts.fields._id === 0 ? 0 : 1;
       var validFields = _.pick(opts.fields, function (value) { return !!value; });


### PR DESCRIPTION
The MongoDB does return an _id field, if you do not explicitly opt out.

The getDocs()'s fields option behavior checked for `-1` to omit fields.
This seems to be wrong, as the MongoDB itself omits fields by `0`.

Also it determined the applied action by the first field only. This ignored all the other fields, which can be mixed.
This implementation still doesn't fully imitate the MongoDB's tough.

Regards!