### PR TITLE
Created ensureIndex() as alias of createIndex()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -95,7 +95,7 @@ module.exports = function Collection(db, state) {
     },
     dropIndex: NotImplemented,
     dropIndexes: NotImplemented,
-    ensureIndex: function (fieldOrSpec, options, callback) { throw Error('deprecated'); },
+    ensureIndex: function (fieldOrSpec, options, callback) { return this.createIndex(fieldOrSpec, options, callback); },
     find: function () {
       var opts = find_options(arguments);
       debug('find %j callback=%s', opts, typeof opts.callback);


### PR DESCRIPTION
According to MongoDB documentation, `ensureIndex()` is an alias of `createIndex()`
https://docs.mongodb.com/manual/reference/method/db.collection.ensureIndex/#db.collection.ensureIndex

It's the db's documentation, not the mongo-native-driver ones. So I'm not too sure about this.