### PR TITLE
Fix: Unset not removing nested values.

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,4 +1,6 @@
 var _ = require('lodash');
+var _unset = require('lodash.unset');
+var deepDiff = require('deep-diff');
 var ObjectId = require('bson-objectid');
 var debug = require('debug')('mongo-mock:collection');
 var asyncish = require('../').asyncish;
@@ -429,10 +431,17 @@ function modify(original, updates, state) {
     debug('conflict found %j', conflict);
     return conflict;
   }
-  // remove unset properties
-  Object.keys(original).forEach(function (k) {
-    if (updated[k] === undefined) delete original[k];
-  });
+
+  var diff = deepDiff(original, updated);
+
+  if (diff != null) {
+    diff.forEach(function (delta) {
+      if (delta.kind === 'D') {
+        _unset(original, delta.path);
+      }
+    });
+  }
+
   _.merge(original, updated, restoreObjectIDs);
 }
 function NotImplemented(){

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "bson-objectid": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson-objectid/-/bson-objectid-1.1.5.tgz",
-      "integrity": "sha1-S54hCpjBxOqp7fY6ygeEyzC3m14="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bson-objectid/-/bson-objectid-1.2.3.tgz",
+      "integrity": "sha512-Q19/ibJQlO1z4UOJTyaEpWmJ+IdPQfvoKRPBy5GADIbByxyxk6lSN5m82KHMmKCygBnvPl7Wd9kLlG5VVCBWQQ=="
     },
     "clone": {
       "version": "2.1.1",
@@ -21,12 +21,17 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "deep-diff": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.1.tgz",
+      "integrity": "sha512-Vkn+eQK6H63gObVi3KWmPMb4RdzMpfdp5t0HNppq8Oc7xbwmvBy5BIHsEYSXOiS9Lr/W+3lF020zyPTsGfea4g=="
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -95,6 +100,11 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "lodash.unset": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
+      "integrity": "sha1-Nw0dPoW3Kn4bDN8tJyEhMG8j5O0="
     },
     "lru-cache": {
       "version": "2.7.3",
@@ -189,7 +199,7 @@
     },
     "should-equal": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
       "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "dependencies": {
     "bson-objectid": "^1.1.4",
     "debug": "^2.1.3",
+    "deep-diff": "^1.0.1",
     "lodash": "^3.6.0",
+    "lodash.unset": "^4.5.2",
     "modifyjs": "^0.3.1",
     "sift": "^3.1.1"
   },


### PR DESCRIPTION
As the name suggests, `$unset` was only applied to shallow values.

Sadly introduces two new deps, one due to the version of `lodash` used by the project.

Though I feel, for a dev library, this is probably acceptable.