### PR TITLE
changed deleteMany to accept filters properly and save the changes

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -7,14 +7,14 @@ var modifyjs = require('modifyjs');
 
 var sift = require('../sift.js');
 
-function addToSet (array, other) {
+function addToSet(array, other) {
   other = _.isArray(other) ? other : [other];
 
   var index = -1,
-      length = array.length,
-      othIndex = -1,
-      othLength = other.length,
-      result = Array(length);
+    length = array.length,
+    othIndex = -1,
+    othLength = other.length,
+    result = Array(length);
 
   while (++index < length) {
     result[index] = array[index];
@@ -30,18 +30,18 @@ function addToSet (array, other) {
 module.exports = function Collection(db, state) {
   var name = state.name;
   var pk = state.pkFactory || ObjectId;
-  debug('initializing instance of `%s` with %s documents', name, state.documents? state.documents.length : undefined);
+  debug('initializing instance of `%s` with %s documents', name, state.documents ? state.documents.length : undefined);
 
   var interface = {
-    get collectionName(){ return name; },
-    get hit(){ NotImplemented() },
-    get name(){ return name; },
-    get namespace(){ return db.databaseName+'.'+name; },
-    get writeConcern(){ NotImplemented() },
+    get collectionName() { return name; },
+    get hit() { NotImplemented() },
+    get name() { return name; },
+    get namespace() { return db.databaseName + '.' + name; },
+    get writeConcern() { NotImplemented() },
 
     aggregate: NotImplemented,
     bulkWrite: NotImplemented,
-    count: function() {
+    count: function () {
       var opts = find_options(arguments);
       return this.find(opts.query || {}, opts).count(opts.callback);
     },
@@ -50,42 +50,49 @@ module.exports = function Collection(db, state) {
     },
     createIndexes: NotImplemented,
     deleteMany: function (filter, options, callback) {
-      callback = arguments[arguments.length-1];
+      callback = arguments[arguments.length - 1];
 
       debug('deleteMany %j', filter);
+      const opts = find_options(arguments);
+      cursor(state.documents || [], opts).toArray((err, docsToRemove) => {
+        debug('docs', docsToRemove);
+        if (docsToRemove.length) {
+          debug(state.documents.length);
+          debug(docsToRemove.length);
+          const idsToRemove = _.map(docsToRemove, '_id');
+          _.remove(state.documents || [], document => _.includes(idsToRemove, document._id));
+          debug(state.documents.length);
 
-      asyncish(function() {
-        var docs = _.remove(state.documents||[], filter);
-        if(docs.length) {
-          if (debug.enabled) debug("removed: " + docs.map(function (doc) { return doc._id; }));
+          // debug(documentsLeft);
+          if (debug.enabled) debug("removed: " + docsToRemove.map(function (doc) { return doc._id; }));
           state.persist();
         }
-        callback(null, {result:{n:docs.length, ok: 1}, deletedCount:docs.length, connection:db});
+        callback(null, { result: { n: docsToRemove.length, ok: 1 }, deletedCount: docsToRemove.length, connection: db });
+        if (typeof callback !== 'function') {
+          return new Promise(function (resolve, reject) {
+            callback = function (e, r) { e ? reject(e) : resolve(r) };
+          })
+        }
       });
-      if(typeof callback!=='function') {
-        return new Promise(function (resolve,reject) {
-          callback = function (e, r) { e? reject(e) : resolve(r) };
-        })
-      }
     },
     deleteOne: function (filter, options, callback) {
-      callback = arguments[arguments.length-1];
+      callback = arguments[arguments.length - 1];
 
       debug('deleteOne %j', filter);
 
-      asyncish(function() {
-        var deletionIndex = _.findIndex(state.documents||[], filter);
+      asyncish(function () {
+        var deletionIndex = _.findIndex(state.documents || [], filter);
         var docs = deletionIndex === -1 ? [] : state.documents.splice(deletionIndex, 1);
 
-        if(deletionIndex > -1) {
+        if (deletionIndex > -1) {
           if (debug.enabled) debug("removed: " + docs.map(function (doc) { return doc._id; }));
           state.persist();
         }
-        callback(null, {result:{n:docs.length, ok: 1}, deletedCount:docs.length, connection:db});
+        callback(null, { result: { n: docs.length, ok: 1 }, deletedCount: docs.length, connection: db });
       });
-      if(typeof callback!=='function') {
-        return new Promise(function (resolve,reject) {
-          callback = function (e, r) { e? reject(e) : resolve(r) };
+      if (typeof callback !== 'function') {
+        return new Promise(function (resolve, reject) {
+          callback = function (e, r) { e ? reject(e) : resolve(r) };
         })
       }
     },
@@ -102,7 +109,7 @@ module.exports = function Collection(db, state) {
 
       var crsr = cursor(state.documents, opts);
 
-      if(!opts.callback)
+      if (!opts.callback)
         return crsr;
 
       asyncish(function () {
@@ -117,7 +124,7 @@ module.exports = function Collection(db, state) {
 
       var crsr = cursor(state.documents, opts);
 
-      if(!opts.callback)
+      if (!opts.callback)
         return crsr.next();
 
       crsr.next().then(function (doc) {
@@ -137,13 +144,13 @@ module.exports = function Collection(db, state) {
     indexes: NotImplemented,
     initializeOrderedBulkOp: NotImplemented,
     initializeUnorderedBulkOp: NotImplemented,
-    insert: function(docs, options, callback) {
+    insert: function (docs, options, callback) {
       debug('insert %j', docs);
-      callback = arguments[arguments.length-1];
+      callback = arguments[arguments.length - 1];
       //if(callback===options) options = {};//ignored when mocking
-      if(!Array.isArray(docs))
+      if (!Array.isArray(docs))
         docs = [docs];
-      if(name==='system.indexes') return interface.createIndexes(docs, callback)
+      if (name === 'system.indexes') return interface.createIndexes(docs, callback)
 
       //make copies to break refs to the persisted docs
       docs = _.cloneDeep(docs, cloneObjectIDs);
@@ -155,15 +162,15 @@ module.exports = function Collection(db, state) {
         var insertedIds = [];
         for (var i = 0; i < docs.length; i++) {
           var doc = docs[i];
-          if(!doc._id) doc._id = pk();
+          if (!doc._id) doc._id = pk();
 
           var conflict = state.findConflict(doc);
-          if(conflict) {
+          if (conflict) {
             state.persist();
             return callback(conflict);
           }
 
-          if(!state.documents) state.documents = [doc];
+          if (!state.documents) state.documents = [doc];
           else state.documents.push(doc);
 
           insertedIds.push(doc._id)
@@ -173,23 +180,23 @@ module.exports = function Collection(db, state) {
         callback(null, {
           insertedIds: insertedIds,
           insertedCount: docs.length,
-          result: {ok:1,n:docs.length},
+          result: { ok: 1, n: docs.length },
           connection: {},
           ops: _.cloneDeep(docs, cloneObjectIDs)
         });
       });
-      if(typeof callback!=='function') {
-        return new Promise(function (resolve,reject) {
-          callback = function (e, r) { e? reject(e) : resolve(r) };
+      if (typeof callback !== 'function') {
+        return new Promise(function (resolve, reject) {
+          callback = function (e, r) { e ? reject(e) : resolve(r) };
         })
       }
     },
     get insertMany() { return this.insert; },
-    insertOne: function(doc, options, callback) {
-      callback = arguments[arguments.length-1];
+    insertOne: function (doc, options, callback) {
+      callback = arguments[arguments.length - 1];
 
       this.insert([doc], options, function (e, r) {
-        if(e) return callback(e)
+        if (e) return callback(e)
         callback(null, {
           insertedId: r.insertedIds[0],
           insertedCount: r.result.n,
@@ -199,9 +206,9 @@ module.exports = function Collection(db, state) {
         })
       })
 
-      if(typeof callback!=='function') {
-        return new Promise(function (resolve,reject) {
-          callback = function (e, r) { e? reject(e) : resolve(r) };
+      if (typeof callback !== 'function') {
+        return new Promise(function (resolve, reject) {
+          callback = function (e, r) { e ? reject(e) : resolve(r) };
         })
       }
     },
@@ -218,21 +225,21 @@ module.exports = function Collection(db, state) {
     },
     reIndex: NotImplemented,
     remove: function (selector, options, callback) {
-      callback = arguments[arguments.length-1];
+      callback = arguments[arguments.length - 1];
 
       debug('remove %j', selector);
 
-      asyncish(function() {
-        var docs = _.remove(state.documents||[], selector);
-        if(docs.length) {
+      asyncish(function () {
+        var docs = _.remove(state.documents || [], selector);
+        if (docs.length) {
           if (debug.enabled) debug("removed: " + docs.map(function (doc) { return doc._id; }));
           state.persist();
         }
-        callback(null, {result:{n:docs.length}, ops:docs, connection:db});
+        callback(null, { result: { n: docs.length }, ops: docs, connection: db });
       });
-      if(typeof callback!=='function') {
-        return new Promise(function (resolve,reject) {
-          callback = function (e, r) { e? reject(e) : resolve(r) };
+      if (typeof callback !== 'function') {
+        return new Promise(function (resolve, reject) {
+          callback = function (e, r) { e ? reject(e) : resolve(r) };
         })
       }
     },
@@ -241,30 +248,30 @@ module.exports = function Collection(db, state) {
     save: NotImplemented,
     stats: NotImplemented,
     update: function (selector, data, options, callback) {
-      callback = arguments[arguments.length-1];
-      if(typeof options!=='object') options = {};
+      callback = arguments[arguments.length - 1];
+      if (typeof options !== 'object') options = {};
 
-      var result = {connection:db};
-      var action = (options.upsert?"upsert: ":"update: ");
+      var result = { connection: db };
+      var action = (options.upsert ? "upsert: " : "update: ");
       debug('%s.%s %j', name, action, selector);
 
-      asyncish(function() {
-        var docs = (options.multi? sift : first)(selector, state.documents||[]) || [];
-        if(!Array.isArray(docs)) docs = [docs];
+      asyncish(function () {
+        var docs = (options.multi ? sift : first)(selector, state.documents || []) || [];
+        if (!Array.isArray(docs)) docs = [docs];
         debug('%s.%s %j', name, action, docs);
 
-        if(!docs.length && options.upsert) {
+        if (!docs.length && options.upsert) {
           var cloned = _.cloneDeep(data.$setOnInsert || data.$set || data, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
           debug('%s.%s checking for index conflict', name, action);
           var conflict = state.findConflict(cloned);
-          if(conflict) {
+          if (conflict) {
             debug('conflict found %j', conflict);
             return callback(conflict);
           }
 
-          if(!state.documents) state.documents = [cloned];
+          if (!state.documents) state.documents = [cloned];
           else state.documents.push(cloned);
 
           result.n = 1;
@@ -283,15 +290,15 @@ module.exports = function Collection(db, state) {
         callback(null, result);
       });
 
-      if(typeof callback!=='function') {
-        return new Promise(function (resolve,reject) {
-          callback = function (e, r) { e? reject(e) : resolve(r) };
+      if (typeof callback !== 'function') {
+        return new Promise(function (resolve, reject) {
+          callback = function (e, r) { e ? reject(e) : resolve(r) };
         })
       }
     },
     updateMany: function (selector, data, options, callback) {
-      callback = arguments[arguments.length-1];
-      if(typeof options!=='object') options = {};
+      callback = arguments[arguments.length - 1];
+      if (typeof options !== 'object') options = {};
 
       var opResult = {
         result: {
@@ -305,26 +312,26 @@ module.exports = function Collection(db, state) {
         upsertedCount: 0,
         upsertedId: null
       };
-      var action = (options.upsert?"upsert: ":"update: ");
+      var action = (options.upsert ? "upsert: " : "update: ");
       debug('%s.%s %j', name, action, selector);
 
-      asyncish(function() {
-        var docs = sift(selector, state.documents||[]) || [];
-        if(!Array.isArray(docs)) docs = [docs];
+      asyncish(function () {
+        var docs = sift(selector, state.documents || []) || [];
+        if (!Array.isArray(docs)) docs = [docs];
         debug('%s.%s %j', name, action, docs);
 
-        if(!docs.length && options.upsert) {
+        if (!docs.length && options.upsert) {
           var cloned = _.cloneDeep(data.$setOnInsert || data.$set, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
           debug('%s.%s checking for index conflict', name, action);
           var conflict = state.findConflict(cloned);
-          if(conflict) {
+          if (conflict) {
             debug('conflict found %j', conflict);
             return callback(conflict);
           }
 
-          if(!state.documents) state.documents = [cloned];
+          if (!state.documents) state.documents = [cloned];
           else state.documents.push(cloned);
 
           opResult.matchedCount = opResult.result.n = 1;
@@ -345,15 +352,15 @@ module.exports = function Collection(db, state) {
         callback(null, opResult);
       });
 
-      if(typeof callback!=='function') {
-        return new Promise(function (resolve,reject) {
-          callback = function (e, r) { e? reject(e) : resolve(r) };
+      if (typeof callback !== 'function') {
+        return new Promise(function (resolve, reject) {
+          callback = function (e, r) { e ? reject(e) : resolve(r) };
         })
       }
     },
     updateOne: function (selector, data, options, callback) {
-      callback = arguments[arguments.length-1];
-      if(typeof options!=='object') options = {};
+      callback = arguments[arguments.length - 1];
+      if (typeof options !== 'object') options = {};
 
       var opResult = {
         result: {
@@ -367,26 +374,26 @@ module.exports = function Collection(db, state) {
         upsertedCount: 0,
         upsertedId: null
       };
-      var action = (options.upsert?"upsert: ":"update: ");
+      var action = (options.upsert ? "upsert: " : "update: ");
       debug('%s.%s %j', name, action, selector);
 
-      asyncish(function() {
-        var docs = first(selector, state.documents||[]) || [];
-        if(!Array.isArray(docs)) docs = [docs];
+      asyncish(function () {
+        var docs = first(selector, state.documents || []) || [];
+        if (!Array.isArray(docs)) docs = [docs];
         debug('%s.%s %j', name, action, docs);
 
-        if(!docs.length && options.upsert) {
+        if (!docs.length && options.upsert) {
           var cloned = _.cloneDeep(data.$setOnInsert || data.$set || data, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
           debug('%s.%s checking for index conflict', name, action);
           var conflict = state.findConflict(cloned);
-          if(conflict) {
+          if (conflict) {
             debug('conflict found %j', conflict);
             return callback(conflict);
           }
 
-          if(!state.documents) state.documents = [cloned];
+          if (!state.documents) state.documents = [cloned];
           else state.documents.push(cloned);
 
           opResult.matchedCount = opResult.result.n = 1;
@@ -405,9 +412,9 @@ module.exports = function Collection(db, state) {
         callback(null, opResult);
       });
 
-      if(typeof callback!=='function') {
-        return new Promise(function (resolve,reject) {
-          callback = function (e, r) { e? reject(e) : resolve(r) };
+      if (typeof callback !== 'function') {
+        return new Promise(function (resolve, reject) {
+          callback = function (e, r) { e ? reject(e) : resolve(r) };
         })
       }
     },
@@ -425,7 +432,7 @@ function modify(original, updates, state) {
   var updated = modifyjs(original, updates);
   updated._id = original._id;
   var conflict = state.findConflict(updated, original);
-  if(conflict) {
+  if (conflict) {
     debug('conflict found %j', conflict);
     return conflict;
   }
@@ -435,11 +442,11 @@ function modify(original, updates, state) {
   });
   _.merge(original, updated, restoreObjectIDs);
 }
-function NotImplemented(){
+function NotImplemented() {
   throw Error('Not Implemented');
 }
 function cloneObjectIDs(value) {
-  return value instanceof ObjectId? ObjectId(value) : undefined;
+  return value instanceof ObjectId ? ObjectId(value) : undefined;
 }
 function restoreObjectIDs(originalValue, updatedValue) {
   return updatedValue && updatedValue.constructor.name === 'ObjectID' && updatedValue.id ? ObjectId(updatedValue.id) : undefined;
@@ -449,16 +456,16 @@ function first(query, collection) {
 }
 
 function find_options(args) {
-  if(!args) args = [];
-  var signature = Array.prototype.map.call(args, function(arg){ return Array.isArray(arg)? "array" : typeof arg }).join();
+  if (!args) args = [];
+  var signature = Array.prototype.map.call(args, function (arg) { return Array.isArray(arg) ? "array" : typeof arg }).join();
   var options = {
     query: args[0],
     fields: args[1],
     skip: 0,
     limit: 0,
-    callback: /function$/.test(signature)? args[args.length-1] : undefined
+    callback: /function$/.test(signature) ? args[args.length - 1] : undefined
   };
-  switch(signature) {
+  switch (signature) {
     //callback?
     case "":
     case "undefined":
@@ -477,21 +484,21 @@ function find_options(args) {
     case "object,undefined,function":
     case "object,object,function":
       //sniff for a 1 or -1 to detect fields object
-      if(!args[1] || Math.abs(args[1][0])===1) {
+      if (!args[1] || Math.abs(args[1][0]) === 1) {
         options.fields = args[1];
       }
       else {
-        if(args[1].skip) options.skip = args[1].skip;
-        if(args[1].limit) options.limit = args[1].limit;
-        if(args[1].fields) options.fields = args[1].fields;
+        if (args[1].skip) options.skip = args[1].skip;
+        if (args[1].limit) options.limit = args[1].limit;
+        if (args[1].fields) options.fields = args[1].fields;
       }
       break;
     //selector, fields, options, callback?
     case "object,object,object":
     case "object,object,object,function":
-      if(args[2].skip) options.skip = args[2].skip;
-      if(args[2].limit) options.limit = args[2].limit;
-      if(args[2].fields) options.fields = args[2].fields;
+      if (args[2].skip) options.skip = args[2].skip;
+      if (args[2].limit) options.limit = args[2].limit;
+      if (args[2].fields) options.fields = args[2].fields;
       break;
     //selector, fields, skip, limit, timeout, callback?
     case "object,object,number,number,number":
@@ -505,7 +512,7 @@ function find_options(args) {
       //if(typeof args[4]==="number") options.timeout = args[4];
       break;
     default:
-      throw new Error("unknown signature: "+ signature);
+      throw new Error("unknown signature: " + signature);
   }
   return options;
 }
@@ -514,7 +521,7 @@ function mapDotNotationToJson(dotNotationObj) {
   var jsonNotation = {};
   var rootKeys = Object.keys(dotNotationObj);
   var cursor = jsonNotation;
-  rootKeys.forEach(function(dotNotationKey) {
+  rootKeys.forEach(function (dotNotationKey) {
     var keys = dotNotationKey.split('.');
     keys.forEach(function (key, i) {
       // Create object if not last key in dot notation, otherwise assign the value


### PR DESCRIPTION
I think my linter picked this up, excuse the new formatting, but there wasn't a linting script within this repo.

This adds deleteMany functionality, using the internal return array from a cursor to find documents that match the deleteMany and then remove them, `_.remove()` was incompatible with `$in` and `$or`