### PR TITLE
Bulk operations

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -58,13 +58,11 @@ function FindOperators(collection, query, ops) {
     remove: function() {
       var process = (doc) => {
         cursor = getLatestCursor();
-        console.log(doc);
         if (!doc) {
           return Promise.resolve();
         }
 
         return collection.remove({_id: doc._id}).then(() => {
-          console.log('Deleted: ' + doc._id);
           return cursor.next().then((d) => process(d));
         });
       };
@@ -89,9 +87,7 @@ function FindOperators(collection, query, ops) {
             if (!doc) {
               return;
             }
-            return collection.deleteOne({_id: doc._id}).then(() => {
-              console.log('Deleted: ' + doc._id);
-            });
+            return collection.deleteOne({_id: doc._id});
           });
         },
       });
@@ -145,6 +141,7 @@ function FindOperators(collection, query, ops) {
       return this;
     },
     collation: NotImplemented,
+    arrayFilters: NotImplemented,
   };
 
   function getLatestCursor() {

--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -94,23 +94,24 @@ function FindOperators(collection, query, ops) {
 
       return this;
     },
-    replaceOne: function(replacement) {
-      ops.push({
-        args: [],
-        fnc: () => {
-          cursor = getLatestCursor();
-          return cursor.next().then((doc) => {
-            if (!doc) {
-              return;
-            }
-
-            return collection.replaceOne({_id: doc._id}, replacement);
-          });
-        }
-      });
-
-      return this;
-    },
+    replaceOne: NotImplemented,
+    // replaceOne: function(replacement) {
+    //   ops.push({
+    //     args: [],
+    //     fnc: () => {
+    //       cursor = getLatestCursor();
+    //       return cursor.next().then((doc) => {
+    //         if (!doc) {
+    //           return;
+    //         }
+    //
+    //         return collection.replaceOne({_id: doc._id}, replacement);
+    //       });
+    //     }
+    //   });
+    //
+    //   return this;
+    // },
     update: function(updateSpec) {
       ops.push({
         args: [],

--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -1,0 +1,159 @@
+module.exports = function Bulk(collection, ordered) {
+  var ops = [];
+  var executedOps = [];
+  var interface = {
+    insert: function(docs, options, callback) {
+      ops.push({
+        args: Array.from(arguments),
+        fnc: collection.insert,
+      });
+
+      return this;
+    },
+    find: function() {
+      return new FindOperators(collection, arguments[0], ops);
+    },
+    getOperations: NotImplemented,
+    tojson: NotImplemented,
+    toString: NotImplemented,
+    execute: function() {
+      if (ordered) {
+        return executeOperations(ops);
+      } else {
+        return executeOperationsParallel(ops);
+      }
+    },
+  };
+
+  //Runs operations only one at a time
+  function executeOperations(ops) {
+    return ops.reduce((acc, op) => {
+      return acc.then(() => {
+        executedOps.push(op);
+        return op.fnc.apply(this, op.args);
+      });
+    }, Promise.resolve());
+  }
+
+  //Exhibits a more "fire and forget" behavior
+  function executeOperationsParallel(ops) {
+    var promises = [];
+
+    for (var i = 0; i < ops.length; i++) {
+      var op = ops[i];
+      promises.push(op.fnc.apply(this, op.args));
+    }
+
+    return Promise.all(promises);
+  }
+
+  return interface;
+};
+
+function FindOperators(collection, query, ops) {
+  var cursor = collection.find(query);
+  var upsert = false;
+
+  var interface = {
+    remove: function() {
+      var process = (doc) => {
+        cursor = getLatestCursor();
+        console.log(doc);
+        if (!doc) {
+          return Promise.resolve();
+        }
+
+        return collection.remove({_id: doc._id}).then(() => {
+          console.log('Deleted: ' + doc._id);
+          return cursor.next().then((d) => process(d));
+        });
+      };
+
+      ops.push({
+        args: [],
+        fnc: () => {
+          return cursor.next().then((d) => {
+            return process(d);
+          });
+        },
+      });
+
+      return this;
+    },
+    removeOne: function() {
+      ops.push({
+        args: [],
+        fnc: () => {
+          cursor = getLatestCursor();
+          return cursor.next().then((doc) => {
+            if (!doc) {
+              return;
+            }
+            return collection.deleteOne({_id: doc._id}).then(() => {
+              console.log('Deleted: ' + doc._id);
+            });
+          });
+        },
+      });
+
+      return this;
+    },
+    replaceOne: function(replacement) {
+      ops.push({
+        args: [],
+        fnc: () => {
+          cursor = getLatestCursor();
+          return cursor.next().then((doc) => {
+            if (!doc) {
+              return;
+            }
+
+            return collection.replaceOne({_id: doc._id}, replacement);
+          });
+        }
+      });
+
+      return this;
+    },
+    update: function(updateSpec) {
+      ops.push({
+        args: [],
+        fnc: () => {
+          return collection.update(query, updateSpec, {
+            multi: true,
+            upsert: upsert,
+          });
+        }
+      });
+
+      return this;
+    },
+    updateOne: function(updateSpec) {
+      ops.push({
+        args: [],
+        fnc: () => {
+          return collection.updateOne(query, updateSpec, {
+            upsert: upsert,
+          });
+        }
+      });
+
+      return this;
+    },
+    upsert: function() {
+      upsert = true;
+      return this;
+    },
+    collation: NotImplemented,
+  };
+
+  function getLatestCursor() {
+    return collection.find(query);
+  }
+
+  return interface;
+}
+
+function NotImplemented(){
+  throw Error('Not Implemented');
+}

--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -1,7 +1,7 @@
 module.exports = function Bulk(collection, ordered) {
   var ops = [];
   var executedOps = [];
-  var interface = {
+  var iface = {
     insert: function(docs, options, callback) {
       ops.push({
         args: Array.from(arguments),
@@ -47,14 +47,14 @@ module.exports = function Bulk(collection, ordered) {
     return Promise.all(promises);
   }
 
-  return interface;
+  return iface;
 };
 
 function FindOperators(collection, query, ops) {
   var cursor = collection.find(query);
   var upsert = false;
 
-  var interface = {
+  var iface = {
     remove: function() {
       var process = (doc) => {
         cursor = getLatestCursor();
@@ -95,23 +95,6 @@ function FindOperators(collection, query, ops) {
       return this;
     },
     replaceOne: NotImplemented,
-    // replaceOne: function(replacement) {
-    //   ops.push({
-    //     args: [],
-    //     fnc: () => {
-    //       cursor = getLatestCursor();
-    //       return cursor.next().then((doc) => {
-    //         if (!doc) {
-    //           return;
-    //         }
-    //
-    //         return collection.replaceOne({_id: doc._id}, replacement);
-    //       });
-    //     }
-    //   });
-    //
-    //   return this;
-    // },
     update: function(updateSpec) {
       ops.push({
         args: [],
@@ -149,7 +132,7 @@ function FindOperators(collection, query, ops) {
     return collection.find(query);
   }
 
-  return interface;
+  return iface;
 }
 
 function NotImplemented(){

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -4,6 +4,7 @@ var debug = require('debug')('mongo-mock:collection');
 var asyncish = require('../').asyncish;
 var cursor = require('./cursor.js');
 var modifyjs = require('modifyjs');
+var bulk = require('./bulk.js');
 
 var sift = require('../sift.js');
 
@@ -159,8 +160,12 @@ module.exports = function Collection(db, state) {
       return db.indexInformation(name, options, callback);
     },
     indexes: NotImplemented,
-    initializeOrderedBulkOp: NotImplemented,
-    initializeUnorderedBulkOp: NotImplemented,
+    initializeOrderedBulkOp: function () {
+      return new bulk(this, true);
+    },
+    initializeUnorderedBulkOp: function () {
+      return new bulk(this, false);
+    },
     insert: function(docs, options, callback) {
       debug('insert %j', docs);
       callback = arguments[arguments.length-1];
@@ -240,7 +245,7 @@ module.exports = function Collection(db, state) {
       // to be materialized and the data to be persisted to disk.
       state.persist();
     },
-    reIndex: NotImplemented,
+    // reIndex: NotImplemented,
     remove: function (selector, options, callback) {
       callback = arguments[arguments.length-1];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-mock",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,7 +16,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -85,12 +85,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -117,8 +117,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -138,7 +138,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -191,8 +191,8 @@
       "resolved": "https://registry.npmjs.org/modifyjs/-/modifyjs-0.3.1.tgz",
       "integrity": "sha1-ckaUd/tMRwlx1hemO6G73pqqx88=",
       "requires": {
-        "clone": "2.1.1",
-        "deep-equal": "1.0.1"
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1"
       }
     },
     "ms": {
@@ -206,7 +206,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -261,7 +261,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "wrappy": {

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -627,6 +627,39 @@ describe('mock tests', function () {
         });
       });
     });
+
+    it('should bulk update', function(done) {
+      collection.should.have.property('initializeOrderedBulkOp');
+      var bulk = collection.initializeOrderedBulkOp();
+      // bulk.insert({
+      //   test: 4321,
+      //   name: 'Cool dude',
+      // });
+      // bulk.find({test: {$exists: false}}).update({
+      //   $set: {
+      //     name: 'Test',
+      //   }
+      // }).update({
+      //   $set: {
+      //     num: 2,
+      //   }
+      // });
+      //
+      // bulk.insert([{
+      //   test: 53553,
+      //   coolpercent: 100,
+      // }]);
+
+      bulk.find({test: {$exists: true}}).remove();
+      // bulk.find({test: {$exists: true}}).removeOne();
+      bulk.execute().then(() => {
+        collection.find({}).toArray()
+          .then((data) => {
+            console.log(data);
+            done();
+          });
+      });
+    }).timeout(0);
   });
 
   describe('cursors', function() {
@@ -775,5 +808,6 @@ describe('mock tests', function () {
         done();
       });
     });
+
   });
 });


### PR DESCRIPTION
@williamkapke 

I have added basic/partial support for bulk operations (`initializeOrderedBulkOp` and `initializeUnorderedBulkOp`).

Something to note is the difference between the **OrderedBulk** and **UnorderedBulk**. In my code, they are actually very similar. The reason for this is due to mongodb being vague on their implementation details in their docs. The most substantial difference I found was 

> With an unordered operations list, MongoDB can execute in parallel the write operations in the list and in any order.

So in the commited code, the **OrderedBulk** executes an operation one after another and in the order that it was given. The **UnorderedBulk** executes its operations in a more "parallel" manner (it really just calls each operation as fast as it can instead of waiting for the last one to finish).

Another difference mentioned in mongodb's documentation to consider for future changes to the bulk operation is

> When executing an ordered list of operations, MongoDB groups the operations by the operation type and contiguity; i.e. contiguous operations of the same type are grouped together. 

and 

> The sizes and grouping mechanics are internal performance details and are subject to change in future versions.

So to truly emulate how mongodb does **OrderedBulk** operations, we will need to refer to the actual source code (which I plan to visit and implement in the near future).

Functions that **have been implemented**:
`collection.initializeOrderedBulkOp()`
`collection.initializeUnorderedBulkOp()`
`Bulk.find()`
`Bulk.insert()`
`Bulk.execute()`
`Bulk.find.remove()`
`Bulk.find.removeOne()`
`Bulk.find.update()`
`Bulk.find.updateOne()`

Functions that **haven't been implemented**:
`Bulk.getOperations()`
`Bulk.find.collation()`
`Bulk.find.arrayFilters()`
`Bulk.find.replaceOne()`

References:
[initializeOrderedBulkOp](https://docs.mongodb.com/manual/reference/method/db.collection.initializeOrderedBulkOp/#db.collection.initializeOrderedBulkOp)

[initializeUnorderedBulkOp](https://docs.mongodb.com/manual/reference/method/db.collection.initializeUnorderedBulkOp)