### PR TITLE
Fix for removal of properties in nested object (Issue #55)

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -458,13 +458,13 @@ function modify(original, updates, state) {
     debug('conflict found %j', conflict);
     return conflict;
   }
+  _.assign(original, updated);
   // remove unset properties
   if (typeof updates.$unset === "object") {
     Object.keys(updates.$unset).forEach(function (k) {
       _.unset(original, k);
     });
   }
-  _.merge(original, updated, restoreObjectIDs);
 }
 function NotImplemented(){
   throw Error('Not Implemented');


### PR DESCRIPTION
Merge is unable to remove properties within nested object. 

https://github.com/williamkapke/mongo-mock/issues/55