### PR TITLE
Fix upsert response

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -145,7 +145,7 @@ module.exports = function Collection(db, state) {
               if (options.upsert) {
                 findResult.lastErrorObject = {
                   n: 1,
-                  updateExisting: !opResult.upsertedCount,
+                  updatedExisting: !opResult.upsertedCount,
                 };
                 if (!!opResult.upsertedCount) findResult.lastErrorObject.upserted = opResult.upsertedId._id.str;
               }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -291,7 +291,10 @@ module.exports = function Collection(db, state) {
         debug('%s.%s %j', name, action, docs);
 
         if(!docs.length && options.upsert) {
-          var cloned = _.cloneDeepWith(data.$setOnInsert || data.$set || data, cloneObjectIDs);
+          var cloneData = {};
+          if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
+          else Object.assign({}, data, selector || {});
+          var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
           debug('%s.%s checking for index conflict', name, action);
@@ -351,7 +354,10 @@ module.exports = function Collection(db, state) {
         debug('%s.%s %j', name, action, docs);
 
         if(!docs.length && options.upsert) {
-          var cloned = _.cloneDeepWith(data.$setOnInsert || data.$set, cloneObjectIDs);
+          var cloneData = {};
+          if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
+          else Object.assign({}, data, selector || {});
+          var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
           debug('%s.%s checking for index conflict', name, action);
@@ -414,7 +420,7 @@ module.exports = function Collection(db, state) {
 
         if(!docs.length && options.upsert) {
           var cloneData = {};
-          if (data.$set || data.$setOnInsert) Object.assign(cloneData, data.$setOnInsert || {}, data.$set || {}, selector || {});
+          if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
           else Object.assign({}, data, selector || {});
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,4 +1,6 @@
 var _ = require('lodash');
+var objectAssignDeep = require('object-assign-deep');
+
 var ObjectId = require('bson-objectid');
 var debug = require('debug')('mongo-mock:collection');
 var asyncish = require('../').asyncish;
@@ -292,8 +294,8 @@ module.exports = function Collection(db, state) {
 
         if(!docs.length && options.upsert) {
           var cloneData = {};
-          if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else Object.assign(cloneData, data, selector || {});
+          if (data.$set || data.$setOnInsert) objectAssignDeep(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
+          else objectAssignDeep(cloneData, data, selector || {});
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
@@ -355,8 +357,8 @@ module.exports = function Collection(db, state) {
 
         if(!docs.length && options.upsert) {
           var cloneData = {};
-          if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else Object.assign(cloneData, data, selector || {});
+          if (data.$set || data.$setOnInsert) objectAssignDeep(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
+          else objectAssignDeep(cloneData, data, selector || {});
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
@@ -420,8 +422,8 @@ module.exports = function Collection(db, state) {
 
         if(!docs.length && options.upsert) {
           var cloneData = {};
-          if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else Object.assign(cloneData, data, selector || {});
+          if (data.$set || data.$setOnInsert) objectAssignDeep(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
+          else objectAssignDeep(cloneData, data, selector || {});
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -293,9 +293,7 @@ module.exports = function Collection(db, state) {
         debug('%s.%s %j', name, action, docs);
 
         if(!docs.length && options.upsert) {
-          var cloneData = {};
-          if (data.$set || data.$setOnInsert) objectAssignDeep(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else objectAssignDeep(cloneData, data, selector || {});
+          var cloneData = upsertClone(selector, data);
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
@@ -356,9 +354,7 @@ module.exports = function Collection(db, state) {
         debug('%s.%s %j', name, action, docs);
 
         if(!docs.length && options.upsert) {
-          var cloneData = {};
-          if (data.$set || data.$setOnInsert) objectAssignDeep(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else objectAssignDeep(cloneData, data, selector || {});
+          var cloneData = upsertClone(selector, data);
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
@@ -421,9 +417,7 @@ module.exports = function Collection(db, state) {
         debug('%s.%s %j', name, action, docs);
 
         if(!docs.length && options.upsert) {
-          var cloneData = {};
-          if (data.$set || data.$setOnInsert) objectAssignDeep(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else objectAssignDeep(cloneData, data, selector || {});
+          var cloneData = upsertClone(selector, data);
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
@@ -495,6 +489,16 @@ function cloneObjectIDs(value) {
 function restoreObjectIDs(originalValue, updatedValue) {
   return updatedValue && updatedValue.constructor.name === 'ObjectID' && updatedValue.id ? ObjectId(updatedValue.id) : undefined;
 }
+
+function upsertClone (selector, data) {
+  if (data.$setOnInsert) {
+    var dataToClone = {};
+    dataToClone.$set = objectAssignDeep({}, data.$set, data.$setOnInsert);
+    return objectAssignDeep({}, modifyjs({}, selector || {}), modifyjs({}, dataToClone));
+  }
+  return objectAssignDeep({}, modifyjs({}, data || {}), modifyjs({}, selector || {}));
+}
+
 function first(query, collection) {
   return collection[sift.indexOf(query, collection)];
 }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -136,10 +136,19 @@ module.exports = function Collection(db, state) {
             ok: 1,
             lastErrorObject: null
           };
-          self.findOne({_id: opResult.upsertedId})
+          const findQuery = { _id: opResult.upsertedId };
+          if (options.upsert === true && opResult.upsertedId._id) findQuery._id = opResult.upsertedId._id;
+          self.findOne(findQuery)
             .catch(callback)
             .then(function (doc) {
               findResult.value = doc;
+              if (options.upsert) {
+                findResult.lastErrorObject = {
+                  n: 1,
+                  updateExisting: !opResult.upsertedCount,
+                };
+                if (!!opResult.upsertedCount) findResult.lastErrorObject.upserted = opResult.upsertedId._id.str;
+              }
               callback(null, findResult);
             });
         })
@@ -404,7 +413,10 @@ module.exports = function Collection(db, state) {
         debug('%s.%s %j', name, action, docs);
 
         if(!docs.length && options.upsert) {
-          var cloned = _.cloneDeepWith(data.$setOnInsert || data.$set || data, cloneObjectIDs);
+          var cloneData = {};
+          if (data.$set || data.$setOnInsert) Object.assign(cloneData, data.$setOnInsert || {}, data.$set || {}, selector || {});
+          else Object.assign({}, data, selector || {});
+          var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
           debug('%s.%s checking for index conflict', name, action);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -136,7 +136,7 @@ module.exports = function Collection(db, state) {
             ok: 1,
             lastErrorObject: null
           };
-          const findQuery = { _id: opResult.upsertedId };
+          var findQuery = { _id: opResult.upsertedId };
           if (options.upsert === true && opResult.upsertedId._id) findQuery._id = opResult.upsertedId._id;
           self.findOne(findQuery)
             .catch(callback)
@@ -293,7 +293,7 @@ module.exports = function Collection(db, state) {
         if(!docs.length && options.upsert) {
           var cloneData = {};
           if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else Object.assign({}, data, selector || {});
+          else Object.assign(cloneData, data, selector || {});
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
@@ -356,7 +356,7 @@ module.exports = function Collection(db, state) {
         if(!docs.length && options.upsert) {
           var cloneData = {};
           if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else Object.assign({}, data, selector || {});
+          else Object.assign(cloneData, data, selector || {});
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 
@@ -421,7 +421,7 @@ module.exports = function Collection(db, state) {
         if(!docs.length && options.upsert) {
           var cloneData = {};
           if (data.$set || data.$setOnInsert) Object.assign(cloneData, selector || {}, data.$setOnInsert || {}, data.$set || {});
-          else Object.assign({}, data, selector || {});
+          else Object.assign(cloneData, data, selector || {});
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
           cloned._id = selector._id || pk();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-mock",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,7 +16,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -85,12 +85,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -117,8 +117,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -138,7 +138,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -191,8 +191,8 @@
       "resolved": "https://registry.npmjs.org/modifyjs/-/modifyjs-0.3.1.tgz",
       "integrity": "sha1-ckaUd/tMRwlx1hemO6G73pqqx88=",
       "requires": {
-        "clone": "2.1.1",
-        "deep-equal": "1.0.1"
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1"
       }
     },
     "ms": {
@@ -200,13 +200,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "object-assign-deep": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-assign-deep/-/object-assign-deep-0.4.0.tgz",
+      "integrity": "sha512-54Uvn3s+4A/cMWx9tlRez1qtc7pN7pbQ+Yi7mjLjcBpWLlP+XbSHiHbQW6CElDiV4OvuzqnMrBdkgxI1mT8V/Q=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -261,7 +266,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "debug": "^2.1.3",
     "lodash": "^4.17.10",
     "modifyjs": "^0.3.1",
+    "object-assign-deep": "^0.4.0",
     "sift": "^3.1.1"
   },
   "devDependencies": {

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -286,7 +286,7 @@ describe('mock tests', function () {
         if (err) return done(err);
         opResult.should.have.properties("ok", "lastErrorObject", "value");
         opResult.lastErrorObject.should.have.property("upserted");
-        opResult.lastErrorObject.should.have.property("updateExisting", false);
+        opResult.lastErrorObject.should.have.property("updatedExisting", false);
         opResult.lastErrorObject.should.have.property("n", 1);
 
         opResult.value.should.have.property("foo", "john");
@@ -307,7 +307,7 @@ describe('mock tests', function () {
     collection.findOneAndUpdate({ test: 1689 }, { $set: { foo: "john" }, $setOnInsert: { bar: "dang" } }, { upsert: true }, function (err, opResult) {
       if (err) return done(err);
       opResult.should.have.properties("ok", "lastErrorObject", "value");
-      opResult.lastErrorObject.should.have.property("updateExisting", true);
+      opResult.lastErrorObject.should.have.property("updatedExisting", true);
       opResult.lastErrorObject.should.have.property("n", 1);
 
       opResult.value.should.have.property("foo", "john");

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -7,7 +7,7 @@ var id = ObjectID();
 MongoClient.persist = "mongo.js";
 
 // this number is used in all the query/find tests, so it's easier to add more docs
-var EXPECTED_TOTAL_TEST_DOCS = 12;
+var EXPECTED_TOTAL_TEST_DOCS = 13;
 
 describe('mock tests', function () {
   var connected_db;
@@ -280,6 +280,47 @@ describe('mock tests', function () {
       });
     });
 
+    it('should create one (findOneAndUpdate) with upsert and no document found', function (done) {
+      //query, data, options, callback
+      collection.findOneAndUpdate({ test: 1689 }, { $set: { foo: "john" }, $setOnInsert: { bar: "dang" } }, { upsert: true }, function (err, opResult) {
+        if (err) return done(err);
+        opResult.should.have.properties("ok", "lastErrorObject", "value");
+        opResult.lastErrorObject.should.have.property("upserted");
+        opResult.lastErrorObject.should.have.property("updateExisting", false);
+        opResult.lastErrorObject.should.have.property("n", 1);
+
+        opResult.value.should.have.property("foo", "john");
+        opResult.value.should.have.property("bar", "dang");
+
+        collection.findOne({ test: 1689 }, function (err, doc) {
+          if (err) return done(err);
+          (!!doc).should.be.true;
+          doc.should.have.property("foo", "john");
+          doc.should.have.property("bar", "dang");
+          done();
+        });
+      });
+    });
+
+  it('should update one (findOneAndUpdate) with upsert and matching document found', function (done) {
+    //query, data, options, callback
+    collection.findOneAndUpdate({ test: 1689 }, { $set: { foo: "john" }, $setOnInsert: { bar: "dang" } }, { upsert: true }, function (err, opResult) {
+      if (err) return done(err);
+      opResult.should.have.properties("ok", "lastErrorObject", "value");
+      opResult.lastErrorObject.should.have.property("updateExisting", true);
+      opResult.lastErrorObject.should.have.property("n", 1);
+
+      opResult.value.should.have.property("foo", "john");
+
+      collection.findOne({ test: 1689 }, function (err, doc) {
+        if (err) return done(err);
+        (!!doc).should.be.true;
+        doc.should.have.property("foo", "john");
+        done();
+      });
+    });
+});
+
     it('should update one (default)', function (done) {
       //query, data, options, callback
       collection.update({test:123}, {$set:{foo:"bar"}}, function (err, result) {
@@ -297,11 +338,11 @@ describe('mock tests', function () {
     it('should update multi', function (done) {
       collection.update({}, {$set:{foo:"bar"}}, {multi:true}, function (err, result) {
         if(err) return done(err);
-        result.n.should.equal(8);
+        result.n.should.equal(9);
 
         collection.find({foo:"bar"}).count(function (err, n) {
           if(err) return done(err);
-          n.should.equal(8);
+          n.should.equal(9);
           done();
         });
       });
@@ -309,14 +350,14 @@ describe('mock tests', function () {
     it('should updateMany', function (done) {
       collection.updateMany({}, {$set:{updateMany:"bar"}}, function (err, opResult) {
         if(err) return done(err);
-        opResult.result.n.should.equal(8);
-        opResult.result.nModified.should.equal(8);
-        opResult.matchedCount.should.equal(8);
-        opResult.modifiedCount.should.equal(8);
+        opResult.result.n.should.equal(9);
+        opResult.result.nModified.should.equal(9);
+        opResult.matchedCount.should.equal(9);
+        opResult.modifiedCount.should.equal(9);
 
         collection.find({updateMany:"bar"}).count(function (err, n) {
           if(err) return done(err);
-          n.should.equal(8);
+          n.should.equal(9);
           done();
         });
       });


### PR DESCRIPTION
#66 was accidentally merged into the wrong branch reopening it here.

$set and $setOnInsert can now be used together in the same update/upsert, as well as a non _id based selector, previously _id was the only selector added