### PR TITLE
Bugs/support for callbacks bulk import mimic driver response

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -1,8 +1,10 @@
+var asyncish = require('../').asyncish;
+
 module.exports = function Bulk(collection, ordered) {
   var ops = [];
   var executedOps = [];
   var iface = {
-    insert: function(docs, options, callback) {
+    insert: function (docs, options, callback) {
       ops.push({
         args: Array.from(arguments),
         fnc: collection.insert,
@@ -16,38 +18,63 @@ module.exports = function Bulk(collection, ordered) {
     getOperations: NotImplemented,
     tojson: NotImplemented,
     toString: NotImplemented,
-    execute: function() {
+    execute: function(callback) {
       if (ordered) {
-        return executeOperations(ops);
+        return executeOperations(ops, callback);
       } else {
-        return executeOperationsParallel(ops);
+        return executeOperationsParallel(ops, callback);
       }
     },
   };
 
   //Runs operations only one at a time
-  function executeOperations(ops) {
-    return ops.reduce((acc, op) => {
-      return acc.then(() => {
-        executedOps.push(op);
-        return op.fnc.apply(this, op.args);
-      });
-    }, Promise.resolve());
+  function executeOperations(operations, callback) {
+    callback = arguments[arguments.length - 1];
+    asyncish(() => {
+      operations.reduce((promiseChain, operation) => {
+        return promiseChain.then(() => {
+          executedOps.push(operation);
+          return operation.fnc.apply(this, operation.args)
+        });
+      }, Promise.resolve([]))
+      .then(() => {
+        callback(null, executedOps);
+      })
+      .catch(callback)
+    });
+    if (typeof callback !== 'function') {
+      return new Promise(function (resolve, reject) {
+        callback = function (e, r) { e ? reject(e) : resolve(r) };
+      })
+    }
   }
 
   //Exhibits a more "fire and forget" behavior
-  function executeOperationsParallel(ops) {
+  function executeOperationsParallel(operations, callback) {
+    callback = arguments[arguments.length - 1];
     var promises = [];
-
-    for (var i = 0; i < ops.length; i++) {
-      var op = ops[i];
-      promises.push(op.fnc.apply(this, op.args));
+    for (var i = 0; i < operations.length; i++) {
+      var operation = operations[i];
+      promises.push(operation.fnc.apply(this, operation.args));
     }
 
-    return Promise.all(promises);
+    asyncish(() => {
+      Promise.all(promises)
+      .then((operations) => {
+        callback(null, operations)
+      })
+      .catch(callback);
+    });
+
+    if (typeof callback !== 'function') {
+      return new Promise(function (resolve, reject) {
+        callback = function (e, r) { e ? reject(e) : resolve(r) };
+      })
+    }
+
   }
 
-  return iface;
+   return iface;
 };
 
 function FindOperators(collection, query, ops) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -164,7 +164,7 @@ module.exports = function Collection(db, state) {
         })
         .catch(callback);
 
-      if(typeof callback!=='function') {
+      if (typeof callback!=='function') {
         return new Promise(function (resolve,reject) {
           callback = function (e, r) { e? reject(e) : resolve(r) };
         })


### PR DESCRIPTION
There was a lack of support around callbacks, which wasn't to spec, updated the functions to support callbacks and use more specific variable names.

TODO: fix responses from executed command, and add `.toJSON()` support 