### PR TITLE
MongoClient.connect: url without database defaults to admin db

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -18,7 +18,7 @@ MongoClient.connect = function(url, options, callback) {
   var server = servers[url.host] || (servers[url.host] = { databases:{}, persist:MongoClient._persist });
   debug('connecting %s%s', url.host, url.pathname);
 
-  var dbname = url.pathname.replace(/^\//, '');
+  var dbname = (url.pathname || '').replace(/^\//, '') || 'admin';
   return new Db(dbname, server).open(callback);
 };
 


### PR DESCRIPTION
In the current mongo-mock version, specifying a connect url without any database throws an error.

The mongo documentation says it should default to admin db: https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html#basic-parts-of-the-url