### PR TITLE
sift.compare stringifies ObjectIds with .toHexString()

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -225,11 +225,14 @@ var Db = module.exports = function(dbname, server) {
         var keys = Object.keys(index.key);
         keys.forEach(function (key) {
           if(!data.hasOwnProperty(key)) data[key] = undefined;
+          if (data[key] === undefined && index.sparse) delete data[key]
         });
         var query = _.pick(data, keys);
         var conflict = _.find(documents, query);
-        if(conflict && conflict!==original)
+        if (_.isEmpty(query)) return; 
+        if(conflict && conflict!==original) {
           return indexError(index, i);
+        }
       }
     },
     toJSON: function () {

--- a/sift.js
+++ b/sift.js
@@ -4,7 +4,7 @@ var sift = require('sift');
 var compare = sift.compare;
 sift.compare = function(a, b) {
   if(a && b && a._bsontype && b._bsontype) {
-    return a.equals(b)? 0 : (compare(time(a), time(b)) || compare(a.str, b.str));
+    return a.equals(b)? 0 : (compare(time(a), time(b)) || compare(a.toHexString(), b.toHexString()));
   }
   return compare(a,b);
 };


### PR DESCRIPTION
instead of .str, which is an internal implementation detail of `bson-objectid`'s ObjectId.
This prevents incorrect equality of ObjectIds imported from `bson` module in a case when their timestamps are equal