### PR TITLE
sift.compare stringifies ObjectIds with .toHexString()

### DIFF
--- a/sift.js
+++ b/sift.js
@@ -4,7 +4,7 @@ var sift = require('sift');
 var compare = sift.compare;
 sift.compare = function(a, b) {
   if(a && b && a._bsontype && b._bsontype) {
-    return a.equals(b)? 0 : (compare(time(a), time(b)) || compare(a.str, b.str));
+    return a.equals(b)? 0 : (compare(time(a), time(b)) || compare(a.toHexString(), b.toHexString()));
   }
   return compare(a,b);
 };


### PR DESCRIPTION
instead of .str, which is an internal implementation detail of `bson-objectid`'s ObjectId.
This prevents incorrect equality of ObjectIds imported from `bson` module in a case when their timestamps are equal