### PR TITLE
Implement a sort by type based on mongodb docs

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -20,13 +20,18 @@ var Cursor = module.exports = function(documents, opts) {
     state = Cursor.OPEN;
     var docs = sift(opts.query, documents);
     if (opts.sort) {
+      // partial implementation of mongodb sorting
+      // https://docs.mongodb.com/manual/reference/bson-type-comparison-order/
+      // TODO: Fully implement this (somehow)
       docs = docs.sort(function(a,b) {
         var retVal = 0;
         for (var field in opts.sort) {
           var aVal = notUndefined(_.get(a, field));
           var bVal = notUndefined(_.get(b, field));
-          if (aVal > bVal) retVal = 1;
-          else if (aVal < bVal) retVal = -1;
+
+          retVal = sortByType(aVal,bVal) || sortByValue(aVal,bVal);
+
+          // apply the order modifier
           retVal *= opts.sort[field];
 
           if (retVal !== 0) break; // no need to continue;
@@ -223,4 +228,37 @@ function applyProjection(docs, fields) {
 
 function cloneObjectIDs(value) {
   return value instanceof ObjectId? ObjectId(value) : undefined;
+}
+
+function sortByType(a, b) {
+  return guessTypeSort(a) - guessTypeSort(b);
+}
+
+function sortByValue(a, b) {
+  if (a < b) return -1;
+  else if (b < a) return 1;
+  return 0;
+}
+
+// https://docs.mongodb.com/manual/reference/bson-type-comparison-order/
+function guessTypeSort(value) {
+  if (value === null || value === undefined) return 2;
+
+  var type = typeof value;
+  switch (type) {
+    case 'number': return 3;
+    case 'string': return 4;
+    case 'boolean': return 9;
+    case 'object':
+      if (Array.isArray(value)) {
+        // A comparison of an empty array (e.g. [ ]) treats the empty array as less than null or a missing field.
+        if (value.length === 0) return 1;
+        else return 6;
+      } else if (value instanceof Date) return 10;
+      else if (value instanceof RegExp) return 12;
+      else if (value instanceof ObjectId) return 8;
+      else return 5;
+  }
+
+  return 13;
 }

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -947,35 +947,97 @@ describe('mock tests', function () {
       });
     });
 
-    it('should sort results by `test` ascending', function (done) {
-      var crsr = collection.find({});
-      crsr.should.have.property('sort');
-      crsr.sort({test: 1}).toArray(function(err, res) {
-        if (err) done(err);
+    describe('sort', function() {
+      var sort_db;
+      var sort_collection;
+      var date = new Date();
+      var docs = [
+        { sortField: null, otherField: 6}, // null
+        { sortField: [ 1 ], otherField: 4}, // array
+        { sortField: 42, otherField: 1}, // number
+        { sortField: true, otherField: 5}, // boolean
+        { sortField: 'foo', otherField: 2}, // string
+        { sortField: /foo/, otherField: 7}, // regex
+        { sortField: { foo: 'bar' }, otherField: 8}, // object
+        { sortField: date, otherField: 3} // date
+      ];
 
-        var sorted = res.sort(function(a,b) {
-          a = typeof a.test === 'undefined' ? null : a.test;
-          b = typeof b.test === 'undefined' ? null : b.test;
-          return a - b;
+      function stripIds(result) {
+        return result.map(function(x) { delete x._id; return x; });
+      }
+
+      before(function (done) {
+        MongoClient.connect("mongodb://somesortserver/sort_mock_database", function(err, db) {
+          sort_db = db;
+          sort_collection = connected_db.collection("sorting");
+          sort_collection.insertMany(docs).then(function() { done() });
         });
-        res.should.eql(sorted);
-        done();
       });
-    });
+      after(function(done) {
+        sort_db.close().then(done).catch(done)
+      });
 
-    it('should sort results by `test` descending', function (done) {
-      var crsr = collection.find({});
-      crsr.should.have.property('sort');
-      crsr.sort({test: -1}).toArray(function(err, res) {
-        if (err) done(err);
+      it('should sort results by type order', function (done) {
+        var sortedDocs = [
+          { sortField: null, otherField: 6}, // null
+          { sortField: 42, otherField: 1}, // number
+          { sortField: 'foo', otherField: 2}, // string
+          { sortField: { foo: 'bar' }, otherField: 8}, // object
+          { sortField: [ 1 ], otherField: 4}, // array
+          { sortField: true, otherField: 5}, // boolean
+          { sortField: date, otherField: 3}, // date
+          { sortField: /foo/, otherField: 7} // regex
+        ]
 
-        var sorted = res.sort(function(a,b) {
-          a = typeof a.test === 'undefined' ? null : a.test;
-          b = typeof b.test === 'undefined' ? null : b.test;
-          return b - a;
+        var crsr = sort_collection.find({});
+        crsr.should.have.property('sort');
+        crsr.sort({sortField: 1}).toArray(function(err, sortRes) {
+          if(err) done(err);
+          stripIds(sortRes).should.eql(sortedDocs);
+          done();
         });
-        res.should.eql(sorted);
-        done();
+      });
+
+      it('should sort results by type order (reversed)', function (done) {
+        var sortedDocs = [
+          { sortField: /foo/, otherField: 7}, // regex
+          { sortField: date, otherField: 3}, // date
+          { sortField: true, otherField: 5}, // boolean
+          { sortField: [ 1 ], otherField: 4}, // array
+          { sortField: { foo: 'bar' }, otherField: 8}, // object
+          { sortField: 'foo', otherField: 2}, // string
+          { sortField: 42, otherField: 1}, // number
+          { sortField: null, otherField: 6}, // null
+        ]
+
+        var crsr = sort_collection.find({});
+        crsr.should.have.property('sort');
+        crsr.sort({sortField: -1}).toArray(function(err, sortRes) {
+          if(err) done(err);
+          stripIds(sortRes).should.eql(sortedDocs);
+          done();
+        });
+      });
+
+      it('should sort results by value', function (done) {
+        var sortedDocs = [
+          { sortField: 42, otherField: 1}, // number
+          { sortField: 'foo', otherField: 2}, // string
+          { sortField: date, otherField: 3}, // date
+          { sortField: [ 1 ], otherField: 4}, // array
+          { sortField: true, otherField: 5}, // boolean
+          { sortField: null, otherField: 6}, // null
+          { sortField: /foo/, otherField: 7}, // regex
+          { sortField: { foo: 'bar' }, otherField: 8}, // object
+        ]
+
+        var crsr = sort_collection.find({});
+        crsr.should.have.property('sort');
+        crsr.sort({otherField: 1}).toArray(function(err, sortRes) {
+          if(err) done(err);
+          stripIds(sortRes).should.eql(sortedDocs);
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
In an attempt to resolve #96 , I added type sorting based on https://docs.mongodb.com/manual/reference/bson-type-comparison-order/

This is only partial as we don't store the data as BSON and some of the sorting requires BSON types.
I basically guess the type the best we can (in JS) and assign a sort order based on the docs.

Past that, I continue the basic `<>=` type comparison. There is more work here in the future if we want to try and emulate how MongoDB sorts arrays and objects but this _should_ help with #96 