### PR TITLE
extended count support (mongodb 4.0.3+)

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -44,9 +44,10 @@ module.exports = function Collection(db, state) {
 
     aggregate: NotImplemented,
     bulkWrite: NotImplemented,
-    count: function () {
-      var opts = find_options(arguments);
-      return this.find(opts.query || {}, opts).count(opts.callback);
+    count: count,
+    countDocuments: count,
+    estimatedDocumentCount: function(options, callback){
+      return this.find({}, options).count(callback);
     },
     createIndex: function (keys, options, callback) {
       return db.createIndex(name, keys, options, callback);
@@ -523,6 +524,11 @@ function upsertClone (selector, data) {
 
 function first(query, collection) {
   return collection[sift.indexOf(query, collection)];
+}
+
+function count() {
+  var opts = find_options(arguments);
+  return this.find(opts.query || {}, opts).count(opts.callback);
 }
 
 function find_options(args) {

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -711,7 +711,7 @@ describe('mock tests', function () {
         });
       });
     });
-    it('should count the number of items in the collection', function(done) {
+    it('should count the number of items in the collection - count method', function(done) {
       collection.should.have.property('count');
       collection.count({}, function(err, cnt) {
         if (err) done(err);
@@ -722,6 +722,27 @@ describe('mock tests', function () {
           singleCnt.should.equal(1);
           done();
         });
+      });
+    });
+    it('should count the number of items in the collection - countDocuments method', function(done) {
+      collection.should.have.property('countDocuments');
+      collection.countDocuments({}, function(err, cnt) {
+        if (err) done(err);
+        cnt.should.equal(EXPECTED_TOTAL_TEST_DOCS);
+
+        collection.countDocuments({ test:333 }, function(err, singleCnt) {
+          if (err) done(err);
+          singleCnt.should.equal(1);
+          done();
+        });
+      });
+    });
+    it('should count the number of items in the collection - estimatedDocumentCount method', function(done) {
+      collection.should.have.property('estimatedDocumentCount');
+      collection.estimatedDocumentCount({}, function(err, cnt) {
+        if (err) done(err);
+        cnt.should.equal(EXPECTED_TOTAL_TEST_DOCS);
+        done();
       });
     });
     it('should drop themselves', function(done) {


### PR DESCRIPTION
added support for:

- collection.countDocuments(query, options); - https://docs.mongodb.com/manual/reference/method/db.collection.countDocuments/
- collection.estimatedDocumentCount(options); - https://docs.mongodb.com/manual/reference/method/db.collection.estimatedDocumentCount/