### PR TITLE
Allow `find(ObjectID)`. Fixes #99

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -7,6 +7,7 @@ var asyncish = require('../').asyncish;
 var cursor = require('./cursor.js');
 var modifyjs = require('modifyjs');
 var bulk = require('./bulk.js');
+var find_options = require('./find_options.js');
 
 var sift = require('../sift.js');
 
@@ -525,66 +526,3 @@ function first(query, collection) {
   return collection[sift.indexOf(query, collection)];
 }
 
-function find_options(args) {
-  if (!args) args = [];
-  var signature = Array.prototype.map.call(args, function (arg) { return Array.isArray(arg) ? "array" : typeof arg }).join();
-  var options = {
-    query: args[0],
-    fields: args[1],
-    skip: 0,
-    limit: 0,
-    callback: /function$/.test(signature) ? args[args.length - 1] : undefined
-  };
-  switch (signature) {
-    //callback?
-    case "":
-    case "undefined":
-    case "function":
-      options.query = {};
-      options.fields = {};
-      break;
-    //selector, callback?,
-    case "object":
-    case "object,function":
-      options.fields = {};
-      break;
-    //selector, fields, callback?
-    //selector, options, callback?
-    case "object,object":
-    case "object,undefined,function":
-    case "object,object,function":
-      //sniff for a 1 or -1 to detect fields object
-      if (!args[1] || Math.abs(args[1][0]) === 1) {
-        options.fields = args[1];
-      }
-      else {
-        if(args[1].skip) options.skip = args[1].skip;
-        if(args[1].limit) options.limit = args[1].limit;
-        if(args[1].fields) options.fields = args[1].fields;
-        if(args[1].projection) options.fields = args[1].projection;
-      }
-      break;
-    //selector, fields, options, callback?
-    case "object,object,object":
-    case "object,object,object,function":
-      if(args[2].skip) options.skip = args[2].skip;
-      if(args[2].limit) options.limit = args[2].limit;
-      if(args[2].fields) options.fields = args[2].fields;
-      if(args[2].projection) options.fields = args[2].projection;
-      break;
-    //selector, fields, skip, limit, timeout, callback?
-    case "object,object,number,number,number":
-    case "object,object,number,number,number,function":
-      options.timeout = args[4];
-    //selector, fields, skip, limit, callback?
-    case "object,object,number,number":
-    case "object,object,number,number,function":
-      options.skip = args[2];
-      options.limit = args[3];
-      //if(typeof args[4]==="number") options.timeout = args[4];
-      break;
-    default:
-      throw new Error("unknown signature: " + signature);
-  }
-  return options;
-}

--- a/lib/find_options.js
+++ b/lib/find_options.js
@@ -1,0 +1,67 @@
+var ObjectID = require('../').ObjectID;
+
+module.exports = function find_options(args) {
+  if(!args) args = [];
+  var signature = Array.prototype.map.call(args, function(arg){ return Array.isArray(arg)? "array" : typeof arg }).join();
+  var options = {
+    query: args[0],
+    fields: args[1],
+    skip: 0,
+    limit: 0,
+    callback: /function$/.test(signature)? args[args.length-1] : undefined
+  };
+  switch(signature) {
+    //callback?
+    case "":
+    case "undefined":
+    case "function":
+      options.query = {};
+      options.fields = {};
+      break;
+    //selector, callback?,
+    case "object":
+    case "object,function":
+      options.fields = {};
+      if (ObjectID.isValid(options.query))
+        options.query = { _id: options.query };
+      break;
+    //selector, fields, callback?
+    //selector, options, callback?
+    case "object,object":
+    case "object,undefined,function":
+    case "object,object,function":
+      //sniff for a 1 or -1 to detect fields object
+      if(!args[1] || Math.abs(args[1][0])===1) {
+        options.fields = args[1];
+      }
+      else {
+        if(args[1].skip) options.skip = args[1].skip;
+        if(args[1].limit) options.limit = args[1].limit;
+        if(args[1].fields) options.fields = args[1].fields;
+        if(args[1].projection) options.fields = args[1].projection;
+      }
+      break;
+    //selector, fields, options, callback?
+    case "object,object,object":
+    case "object,object,object,function":
+      if(args[2].skip) options.skip = args[2].skip;
+      if(args[2].limit) options.limit = args[2].limit;
+      if(args[2].fields) options.fields = args[2].fields;
+      if(args[2].projection) options.fields = args[2].projection;
+      break;
+    //selector, fields, skip, limit, timeout, callback?
+    case "object,object,number,number,number":
+    case "object,object,number,number,number,function":
+      options.timeout = args[4];
+    //selector, fields, skip, limit, callback?
+    case "object,object,number,number":
+    case "object,object,number,number,function":
+      options.skip = args[2];
+      options.limit = args[3];
+      //if(typeof args[4]==="number") options.timeout = args[4];
+      break;
+    default:
+      throw new Error("unknown signature: "+ signature);
+  }
+  return options;
+}

--- a/mongo-mock.js
+++ b/mongo-mock.js
@@ -7,72 +7,8 @@ module.exports = {
   asyncish: function asyncish(callback) {
     setTimeout(callback, Math.random()*(delay));
   },
-  find_options: find_options,
+  get find_options() { return require('./lib/find_options.js') },
   get MongoClient() { return require('./lib/mongo_client.js') },
   get ObjectId() { return require('bson-objectid') },
   get ObjectID() { return require('bson-objectid') }
 };
-
-var noop = Boolean;
-function find_options(args) {
-  if(!args) args = [];
-  var signature = Array.prototype.map.call(args, function(arg){ return Array.isArray(arg)? "array" : typeof arg }).join();
-  var options = {
-    query: args[0],
-    fields: args[1],
-    skip: 0,
-    limit: 0,
-    callback: /function$/.test(signature)? args[args.length-1] : noop
-  };
-  switch(signature) {
-    //callback?
-    case "":
-    case "function":
-      options.query = {};
-      options.fields = {};
-      break;
-    //selector, callback?,
-    case "object":
-    case "object,function":
-      options.fields = {};
-      break;
-    //selector, fields, callback?
-    //selector, options, callback?
-    case "object,object":
-    case "object,undefined,function":
-    case "object,object,function":
-      //sniff for a 1 or -1 to detect fields object
-      if(!args[1] || Math.abs(args[1][0])===1) {
-        options.fields = args[1];
-      }
-      else {
-        if(args[1].skip) options.skip = args[1].skip;
-        if(args[1].limit) options.limit = args[1].limit;
-        if(args[1].fields) options.fields = args[1].fields;
-        if(args[1].projection) options.fields = args[1].projection;
-      }
-      break;
-    //selector, fields, options, callback?
-    case "object,object,object":
-    case "object,object,object,function":
-      if(args[2].skip) options.skip = args[2].skip;
-      if(args[2].limit) options.limit = args[2].limit;
-      if(args[2].fields) options.fields = args[2].fields;
-      if(args[2].projection) options.fields = args[2].projection;
-      break;
-    //selector, fields, skip, limit, timeout, callback?
-    case "object,object,number,number,number":
-    case "object,object,number,number,number,function":
-      options.timeout = args[4];
-    //selector, fields, skip, limit, callback?
-    case "object,object,number,number":
-    case "object,object,number,number,function":
-      options.skip = args[2];
-      options.limit = args[3];
-      //if(typeof args[4]==="number") options.timeout = args[4];
-      break;
-    default:
-      throw new Error("unknown signature: "+ signature);
-  }
-  return options;
-}

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -255,6 +255,19 @@ describe('mock tests', function () {
         done();
       });
     });
+    it('should find by an ObjectID', function (done) {
+      collection.find({_id:ObjectID(id.toHexString())}).toArray(function (err, results) {
+        if(err) return done(err);
+        (!!results).should.be.true;
+        results.should.have.length(1);
+        var doc = results[0];
+        doc.should.have.property('_id');
+        id.toHexString().should.eql(doc._id.toHexString());
+        doc.should.have.property('test', 456);
+        doc.should.have.property('foo', true);
+        done();
+      });
+    });
     it('should findOne by an ObjectID', function (done) {
       collection.findOne({_id:id}, function (err, doc) {
         if(err) return done(err);

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,16 +1,16 @@
 var should = require('should');
-var fo = require('../').find_options;
+var mongo = require('../');
+var fo = require('../lib/find_options.js');
 function find_options() {
   return fo(arguments);
 }
 
 describe('options tests', function () {
   var cb = function(){};
-  var noop = Boolean;
 
   it('should accept signature: empty arguments', function(){
     var options = find_options();
-    options.should.eql({ callback:noop, fields:{}, limit:0, query:{}, skip:0 });
+    options.should.eql({ callback:undefined, fields:{}, limit:0, query:{}, skip:0 });
   });
   it('should accept signature: "callback"', function(){
     var options = find_options(cb);
@@ -18,7 +18,12 @@ describe('options tests', function () {
   });
   it('should accept signature: "selector"', function(){
     var options = find_options({_id:"ABC123"});
-    options.should.eql({ callback:noop, fields:{}, limit:0, query:{_id:"ABC123"}, skip:0 });
+    options.should.eql({ callback:undefined, fields:{}, limit:0, query:{_id:"ABC123"}, skip:0 });
+  });
+  it('should handle ObjectIds', function(){
+    var id = mongo.ObjectID();
+    var options = find_options(id);
+    options.should.eql({ callback:undefined, fields:{}, limit:0, query:{_id:id}, skip:0 });
   });
   it('should accept signature: "selector, callback"', function(){
     var options = find_options({_id:"ABC123"}, cb);
@@ -26,7 +31,7 @@ describe('options tests', function () {
   });
   it('should accept signature: "selector, fields"', function(){
     var options = find_options({_id:"ABC123"}, {_id:-1});
-    options.should.eql({ callback:noop, fields:{_id:-1}, limit:0, query:{_id:"ABC123"}, skip:0 });
+    options.should.eql({ callback:undefined, fields:{_id:-1}, limit:0, query:{_id:"ABC123"}, skip:0 });
   });
   it('should accept signature: "selector, fields, callback"', function(){
     var options = find_options({_id:"ABC123"}, {_id:-1}, cb);
@@ -38,11 +43,11 @@ describe('options tests', function () {
   });
   it('should accept signature: "selector, options"', function(){
     var options = find_options({_id:"ABC123"}, {fields:{_id:-1}, skip:100});
-    options.should.eql({ callback:noop, fields:{_id:-1}, limit:0, query:{_id:"ABC123"}, skip:100 });
+    options.should.eql({ callback:undefined, fields:{_id:-1}, limit:0, query:{_id:"ABC123"}, skip:100 });
   });
   it('should accept signature: "selector, options"', function(){
     var options = find_options({_id:"ABC123"}, {projection:{_id:-1}, skip:100});
-    options.should.eql({ callback:noop, fields:{_id:-1}, limit:0, query:{_id:"ABC123"}, skip:100 });
+    options.should.eql({ callback:undefined, fields:{_id:-1}, limit:0, query:{_id:"ABC123"}, skip:100 });
   });
   it('should accept signature: "selector, options, callback"', function(){
     var options = find_options({_id:"ABC123"}, {fields:{_id:-1}, skip:100}, cb);
@@ -54,7 +59,7 @@ describe('options tests', function () {
   });
   it('should accept signature: "selector, fields, options"', function(){
     var options = find_options({_id:"ABC123"}, {_id:-1}, {skip:100});
-    options.should.eql({ callback:noop, fields:{_id:-1}, limit:0, query:{_id:"ABC123"}, skip:100 });
+    options.should.eql({ callback:undefined, fields:{_id:-1}, limit:0, query:{_id:"ABC123"}, skip:100 });
   });
   it('should accept signature: "selector, fields, options, callback"', function(){
     var options = find_options({_id:"ABC123"}, {_id:-1}, {skip:100}, cb);
@@ -62,7 +67,7 @@ describe('options tests', function () {
   });
   it('should accept signature: "selector, fields, skip, limit"', function(){
     var options = find_options({_id:"ABC123"}, {_id:-1}, 200, 100);
-    options.should.eql({ callback:noop, fields:{_id:-1}, limit:100, query:{_id:"ABC123"}, skip:200 });
+    options.should.eql({ callback:undefined, fields:{_id:-1}, limit:100, query:{_id:"ABC123"}, skip:200 });
   });
   it('should accept signature: "selector, fields, skip, limit, callback"', function(){
     var options = find_options({_id:"ABC123"}, {_id:-1}, 200, 100, cb);
@@ -70,7 +75,7 @@ describe('options tests', function () {
   });
   it('should accept signature: "selector, fields, skip, limit, timeout"', function(){
     var options = find_options({_id:"ABC123"}, {_id:-1}, 200, 100, 600000);
-    options.should.eql({ callback:noop, fields:{_id:-1}, limit:100, query:{_id:"ABC123"}, skip:200, timeout:600000 });
+    options.should.eql({ callback:undefined, fields:{_id:-1}, limit:100, query:{_id:"ABC123"}, skip:200, timeout:600000 });
   });
   it('should accept signature: "selector, fields, skip, limit, timeout, callback"', function(){
     var options = find_options({_id:"ABC123"}, {_id:-1}, 200, 100, 600000, cb);


### PR DESCRIPTION
Turns out I had `find_options` in 2 places accidentally. Much of the changes you see in here are from moving that to a dedicated file.