### PR TITLE
serialize data with new version of bson-objectid

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -29,7 +29,10 @@ function persist() {
   debug('persisting to %s', filename);
 
   var out = "var ObjectID = require('bson-objectid');\n\nmodule.exports = ";
-  ObjectId.prototype.toJSON = ObjectId.prototype.inspect;
+  
+  var inspect = (Symbol && Symbol.for('nodejs.util.inspect.custom')) || 'inspect';
+
+  ObjectId.prototype.toJSON = ObjectId.prototype[inspect] || ObjectId.prototype.inspect;
   out += JSON.stringify(servers, null, 2).replace(/"ObjectID\(([0-9a-f]{24})\)"/g, 'ObjectID("$1")');
   ObjectId.prototype.toJSON = ObjectId.prototype.toHexString;
 


### PR DESCRIPTION
Hi, I had an issue with persisting data. 
in new versions of node, the bson-objectid module is using the Symbol over the name 'inspect'.

see the bson-objectId code here:
https://unpkg.com/browse/bson-objectid@1.3.0/objectid.js

how do you like this change?