### PR TITLE
Fix wrong returned _id in updateOne in some cases

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 var _ = require('lodash');
 var objectAssignDeep = require('object-assign-deep');
 
@@ -517,12 +518,86 @@ function restoreObjectIDs(originalValue, updatedValue) {
   return updatedValue && updatedValue.constructor.name === 'ObjectID' && updatedValue.id ? ObjectId(updatedValue.id) : undefined;
 }
 
+function isOperator(key) {
+  return key.length > 0 && key[0] === '$';
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isProducingEmptyObject(obj) {
+  assert(isPlainObject(obj), 'Invalid "obj" argument. Must be a plain object.');
+
+  for (const key of Object.keys(obj)) {
+      if (key === '$and' || !isOperator(key)) {
+          return false;
+      }
+  }
+
+  return true;
+}
+
+function operatorArrayToNormalizedObject(array, result) {
+  assert(Array.isArray(array), 'Invalid "array" argument. Must be an array.');
+
+  for (const item of array) {
+    assert(isPlainObject(item), 'MongoError: $or/$and/$nor entries need to be full objects.');
+
+    for (const itemKey of Object.keys(item)) {
+        assert(!Boolean(result[itemKey]), `MongoError: cannot infer query fields to set, path '${itemKey}' is matched twice.`);
+    }
+
+    normalizeSelectorToData(item, result);
+  }
+}
+
+/*
+Normalizing a selector object to data object here means flattening $and operators,
+getting rid of $or and $nor operators, conserving the structure when needed.
+*/
+function normalizeSelectorToData(obj, result) {
+  result = result || {};
+
+  assert(isPlainObject(obj), 'Invalid "obj" argument. Must be a plain object.');
+
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+
+    // Normalize the $and operator array.
+    if (key === '$and') {
+      operatorArrayToNormalizedObject(val, result); // Merge into result.
+      continue;
+    }
+
+    // Skip other operators ($or and $nor).
+    if (isOperator(key)) {
+      continue;
+    }
+
+    // Process non plain objects as is.
+    if (!isPlainObject(val)) {
+      result[key] = val;
+      continue;
+    }
+
+    // Ensure processed object would still be meaningful.
+    if (!isProducingEmptyObject(val)) {
+      result[key] = normalizeSelectorToData(val);
+    }
+  }
+
+  return result;
+}
+
 function upsertClone (selector, data) {
   if (data.$setOnInsert) {
     var dataToClone = {};
     dataToClone.$set = objectAssignDeep({}, data.$set, data.$setOnInsert);
+    selector = normalizeSelectorToData(selector);
     return objectAssignDeep({}, modifyjs({}, selector || {}), modifyjs({}, dataToClone));
   }
+  selector = normalizeSelectorToData(selector);
   return objectAssignDeep({}, modifyjs({}, data || {}), modifyjs({}, selector || {}));
 }
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -447,7 +447,7 @@ module.exports = function Collection(db, state) {
         if(!docs.length && options.upsert) {
           var cloneData = upsertClone(selector, data);
           var cloned = _.cloneDeepWith(cloneData, cloneObjectIDs);
-          cloned._id = selector._id || pk();
+          cloned._id = cloned._id || pk();
 
           debug('%s.%s checking for index conflict', name, action);
           var conflict = state.findConflict(cloned);

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -503,6 +503,19 @@ describe('mock tests', function () {
       });
     });
 
+    it('should create one (findOneAndUpdate) with upsert and no document found, using correct _id', function (done) {
+      //query, data, options, callback
+      collection.findOneAndUpdate({ $and: [{ _id: 123 }, { timestamp: 1 }] }, { $set: { foo: "alice" } }, { upsert: true }, function (err, opResult) {
+        if (err) return done(err);
+        opResult.value.should.have.property("_id", 123);
+        opResult.value.should.have.property("foo", "alice");
+
+        collection.remove({ _id: 123 }, function () {
+          done();
+        });
+      });
+    });
+
     it('should update one (default)', function (done) {
       //query, data, options, callback
       collection.update({test:123}, {$set:{foo:"bar"}}, function (err, opResult) {

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -383,6 +383,126 @@ describe('mock tests', function () {
     });
 });
 
+    it('should create one (findOneAndUpdate) with upsert and no document found, complex filter', function (done) {
+      //query, data, options, callback
+      collection.findOneAndUpdate({ $and: [{ test: 1690 }, { another_test: 1691 }] }, { $set: { foo: "alice" }, $setOnInsert: { bar: "bob" } }, { upsert: true }, function (err, opResult) {
+        if (err) return done(err);
+        opResult.should.have.properties("ok", "lastErrorObject", "value");
+        opResult.lastErrorObject.should.have.property("upserted");
+        opResult.lastErrorObject.should.have.property("updatedExisting", false);
+        opResult.lastErrorObject.should.have.property("n", 1);
+
+        opResult.value.should.have.property("foo", "alice");
+        opResult.value.should.have.property("bar", "bob");
+
+        collection.findOne({ test: 1690, another_test: 1691 }, function (err, doc) {
+          if (err) return done(err);
+          (!!doc).should.be.true;
+          doc.should.have.property("foo", "alice");
+          doc.should.have.property("bar", "bob");
+          done();
+        });
+      });
+    });
+
+    it('should update one (findOneAndUpdate) with upsert and matching document found, complex filter', function (done) {
+      //query, data, options, callback
+      collection.findOneAndUpdate({ $and: [{ test: 1690 }, { another_test: 1691 }] }, { $set: { foo: "alice2" }, $setOnInsert: { bar: "bob2" } }, { upsert: true }, function (err, opResult) {
+        if (err) return done(err);
+
+        opResult.should.have.properties("ok", "lastErrorObject", "value");
+        opResult.lastErrorObject.should.have.property("updatedExisting", true);
+        opResult.lastErrorObject.should.have.property("n", 1);
+
+        opResult.value.should.have.property("foo", "alice2");
+        opResult.value.should.have.property("bar", "bob"); // Update here, no insertion.
+
+        function cleanup(cb) {
+          collection.remove({ test: 1690, another_test: 1691 }, cb);
+        }
+
+        collection.findOne({ test: 1690, another_test: 1691 }, function (err, doc) {
+          if (err) {
+            return cleanup(function () {
+              done(err);
+            });
+          }
+          (!!doc).should.be.true;
+          doc.should.have.property("foo", "alice2");
+
+          cleanup(done);
+        });
+      });
+    });
+
+    it('should create one (findOneAndUpdate) with upsert and no document found, more complex filter', function (done) {
+      //query, data, options, callback
+      collection.findOneAndUpdate({ $and: [{ test: 1790 }, { timestamp: { $lt: 1 } }] }, { $set: { foo: "alice", timestamp: 1 }, $setOnInsert: { bar: "bob" } }, { upsert: true }, function (err, opResult) {
+        if (err) return done(err);
+        opResult.should.have.properties("ok", "lastErrorObject", "value");
+        opResult.lastErrorObject.should.have.property("upserted");
+        opResult.lastErrorObject.should.have.property("updatedExisting", false);
+        opResult.lastErrorObject.should.have.property("n", 1);
+
+        opResult.value.should.have.property("test");
+        opResult.value.should.have.property("foo", "alice");
+        opResult.value.should.have.property("bar", "bob");
+
+        collection.findOne({ test: 1790 }, function (err, doc) {
+          if (err) return done(err);
+          (!!doc).should.be.true;
+          doc.should.have.property("foo", "alice");
+          doc.should.have.property("bar", "bob");
+          doc.should.have.property("timestamp", 1);
+          done();
+        });
+      });
+    });
+
+    it('should not update one (findOneAndUpdate) with upsert and no matching document found, more complex filter', function (done) {
+      //query, data, options, callback
+      collection.findOneAndUpdate({ $and: [{ test: 1790 }, { timestamp: { $lt: 1 } }] }, { $set: { foo: "alice2", timestamp: 1 }, $setOnInsert: { bar: "bob2" } }, { upsert: true }, function (err, opResult) {
+        if (err) {
+          if (err.code !== 11000) {
+            return done(err);
+          }
+        }
+
+        done();
+      });
+    });
+
+    it('should update one (findOneAndUpdate) with upsert and document found, more complex filter', function (done) {
+      //query, data, options, callback
+      collection.findOneAndUpdate({ $and: [{ test: 1790 }, { timestamp: { $lt: 2 } }] }, { $set: { foo: "alice3", timestamp: 2 }, $setOnInsert: { bar: "bob3" } }, { upsert: true }, function (err, opResult) {
+        if (err) return done(err);
+        opResult.should.have.properties("ok", "lastErrorObject", "value");
+        opResult.lastErrorObject.should.have.property("updatedExisting", true);
+        opResult.lastErrorObject.should.have.property("n", 1);
+
+        opResult.value.should.have.property("test");
+        opResult.value.should.have.property("foo", "alice3");
+        opResult.value.should.have.property("bar", "bob");
+
+        function cleanup(cb) {
+          collection.remove({ test: 1790 }, cb);
+        }
+
+        collection.findOne({ test: 1790 }, function (err, doc) {
+          if (err) {
+            return cleanup(function () {
+              done(err);
+            });
+          }
+          (!!doc).should.be.true;
+          doc.should.have.property("foo", "alice3");
+          doc.should.have.property("bar", "bob");
+          doc.should.have.property("timestamp", 2);
+          cleanup(done);
+        });
+      });
+    });
+
     it('should update one (default)', function (done) {
       //query, data, options, callback
       collection.update({test:123}, {$set:{foo:"bar"}}, function (err, opResult) {


### PR DESCRIPTION
In the case the query look like this:

```js
findOneAndUpdate({ $and: [{ _id: 123 }, { timestamp: 1 }] }, ...
```

The field `id` is not obviously apparent in the selector object, hence the following line failing by producing a new ObjectID each time:

```js
cloned._id = selector._id || pk();
```
(https://github.com/williamkapke/mongo-mock/blob/master/lib/collection.js#L449)

The correct thing to do is to grab `_id` from the cloned object, because this one is the resolved selector in case of non-obvious queries. It doesn't break existing code, because in case of queries without `_id` (obvious or not) a new ObjectID is created, falling back to current behavior.

**Note:** This PR depends on #114.