### PR TITLE
Allow update without upsert when no docs match

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -463,7 +463,7 @@ module.exports = function Collection(db, state) {
           opResult.upsertedCount = opResult.result.nModified = 1;
           opResult.upsertedId = { _id: cloned._id };
         }
-        else {
+        else if (docs.length > 0) {
           debug('%s.%s checking for index conflicts', name, action);
           var conflict = modify(docs[0], data, state);
           if (conflict) return callback(conflict);

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -516,6 +516,17 @@ describe('mock tests', function () {
       });
     });
 
+    it('should update nothing (findOneAndUpdate) without upsert and no document found', function (done) {
+      //query, data, options, callback
+      collection.findOneAndUpdate({ $and: [{ _id: 123 }, { timestamp: 1 }] }, { $set: { foo: "alice" } }, { upsert: false }, function (err, opResult) {
+        if (err) return done(err);
+        if (opResult.value !== null) {
+          throw new Error('opResult.value should be null.');
+        }
+        done();
+      });
+    });
+
     it('should update one (default)', function (done) {
       //query, data, options, callback
       collection.update({test:123}, {$set:{foo:"bar"}}, function (err, opResult) {

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -520,9 +520,7 @@ describe('mock tests', function () {
       //query, data, options, callback
       collection.findOneAndUpdate({ $and: [{ _id: 123 }, { timestamp: 1 }] }, { $set: { foo: "alice" } }, { upsert: false }, function (err, opResult) {
         if (err) return done(err);
-        if (opResult.value !== null) {
-          throw new Error('opResult.value should be null.');
-        }
+        opResult.should.have.property("value", null);
         done();
       });
     });


### PR DESCRIPTION
I added a unit test that indeed fails without the fix,
Since I'm not sure how to check against `null` with mocha, I simply used an inequality and an throw.

Closes #107 

Note that this may also close issue 108 (#108) as it seems to be a duplicate.