### PR TITLE
Fix false positive fields options

### DIFF
--- a/lib/find_options.js
+++ b/lib/find_options.js
@@ -5,7 +5,7 @@ module.exports = function find_options(args) {
   var signature = Array.prototype.map.call(args, function(arg){ return Array.isArray(arg)? "array" : typeof arg }).join();
   var options = {
     query: args[0],
-    fields: args[1],
+    fields: {},
     skip: 0,
     limit: 0,
     callback: /function$/.test(signature)? args[args.length-1] : undefined
@@ -16,12 +16,10 @@ module.exports = function find_options(args) {
     case "undefined":
     case "function":
       options.query = {};
-      options.fields = {};
       break;
     //selector, callback?,
     case "object":
     case "object,function":
-      options.fields = {};
       if (ObjectID.isValid(options.query))
         options.query = { _id: options.query };
       break;
@@ -44,6 +42,7 @@ module.exports = function find_options(args) {
     //selector, fields, options, callback?
     case "object,object,object":
     case "object,object,object,function":
+      options.fields = args[1];
       if(args[2].skip) options.skip = args[2].skip;
       if(args[2].limit) options.limit = args[2].limit;
       if(args[2].fields) options.fields = args[2].fields;
@@ -52,10 +51,12 @@ module.exports = function find_options(args) {
     //selector, fields, skip, limit, timeout, callback?
     case "object,object,number,number,number":
     case "object,object,number,number,number,function":
+      options.fields = args[1];
       options.timeout = args[4];
     //selector, fields, skip, limit, callback?
     case "object,object,number,number":
     case "object,object,number,number,function":
+      options.fields = args[1];
       options.skip = args[2];
       options.limit = args[3];
       //if(typeof args[4]==="number") options.timeout = args[4];

--- a/lib/find_options.js
+++ b/lib/find_options.js
@@ -29,7 +29,7 @@ module.exports = function find_options(args) {
     case "object,undefined,function":
     case "object,object,function":
       //sniff for a 1 or -1 to detect fields object
-      if(!args[1] || Math.abs(args[1][0])===1) {
+      if(!args[1] || Math.abs(args[1][Object.keys(args[1])[0]])===1) {
         options.fields = args[1];
       }
       else {


### PR DESCRIPTION
Before this the following valid call to `find`:

```js
.find(
  { foo: 'bar' },
  { sort: { orderPriority: -1, name: 1 } }
)
```

would be wrongly interpreted as:

```js
{
  query: { foo: 'bar' },
  fields: { sort: { orderPriority: -1, name: 1 } },
  // ...
}
```

This patch fixes that by only setting `fields` when it's explicitly passed in the given signature.