### PR TITLE
feat: cursor should be async iterable

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -206,6 +206,15 @@ var Cursor = module.exports = function(documents, opts) {
       this.streamOptions = options || {};
       return this;
     },
+
+    [Symbol.asyncIterator]: function () {
+      return {
+        next: () => this.next().then(value => ({
+          value,
+          done: value === null || value === undefined
+        }))
+      }
+    },
   };
 
   iface.__proto__ = EventEmitter.prototype;

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -1360,6 +1360,16 @@ describe('mock tests', function () {
       });
     });
 
+    it('should be async iterable', async function () {
+      var results = [];
+      var crsr = collection.find({});
+      crsr.should.have.property('on');
+      for await (const data of crsr) {
+        results.push(data)
+      }
+      results.length.should.equal(EXPECTED_TOTAL_TEST_DOCS);
+    });
+
     it('should compute total with forEach', function (done) {
       collection.insertMany([
         { testForEach: 1111111, value: 1 },


### PR DESCRIPTION
The current implementation of Cursor is not async iterable, i.e. it is not possible to use `for await ... of`. This PR fixes this issue.

Fixes #138 