### PR TITLE
Add bulkWrite implementation

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -45,7 +45,69 @@ module.exports = function Collection(db, state) {
     get writeConcern() { NotImplemented() },
 
     aggregate: NotImplemented,
-    bulkWrite: NotImplemented,
+    bulkWrite: function (operations, options, callback) {
+      const promises = []
+  
+      for (const operation of operations) {
+        let promise = null
+    
+        // Determine which operation to forward to
+        if (operation.insertOne) {
+          const { document } = operation.insertOne
+          promise = this.insertOne(document, options)
+        } else if (operation.updateOne) {
+          const { filter, update, ...opts } = operation.updateOne
+          promise = this.updateOne(filter, update, { ...options, ...opts })
+        } else if (operation.updateMany) {
+          const { filter, update, ...opts } = operation.updateMany
+          promise = this.updateMany(filter, update, { ...options, ...opts })
+        } else if (operation.deleteOne) {
+          const { filter } = operation.deleteOne
+          promise = this.deleteOne(filter, options)
+        } else if (operation.deleteMany) {
+          const { filter } = operation.deleteMany
+          promise = this.deleteMany(filter, options)
+        } else if (operation.replaceOne) {
+          const { filter, replacement, ...opts } = operation.replaceOne
+          promise = this.replaceOne(filter, replacement, { ...options, ...opts })
+        }
+        
+        if (promise) {
+          // Add the operation results to the list
+          promises.push(promise)
+        }
+      }
+
+      Promise.all(promises).then(function(values) {
+        // Loop through all operation results, and aggregate
+        // the result object
+        let ops = []
+        let n = 0
+        for (const value of values) {
+          if (value.insertedId || value.insertedIds) {
+            ops = [...ops, ...value.ops]
+          }
+          n += value.result.n
+        }
+
+        callback(null, {
+          ops,
+          connection: db,
+          result: {
+            ok: 1,
+            n
+          }
+        })
+      }).catch(function (error) {
+        callback(error, null)
+      })
+
+      if (typeof callback !== 'function') {
+        return new Promise(function(resolve, reject) {
+          callback = function(e, r) { e ? reject(e) : resolve(r); };
+        });
+      }
+    },
     count: count,
     countDocuments: count,
     estimatedDocumentCount: function(options, callback){

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -70,6 +70,8 @@ module.exports = function Collection(db, state) {
         } else if (operation.replaceOne) {
           const { filter, replacement, ...opts } = operation.replaceOne
           promise = this.replaceOne(filter, replacement, { ...options, ...opts })
+        } else {
+          throw Error('bulkWrite only supports insertOne, updateOne, updateMany, deleteOne, deleteMany')
         }
         
         if (promise) {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -49,7 +49,7 @@ module.exports = function Collection(db, state) {
       const promises = []
   
       for (const operation of operations) {
-        let promise = null
+        let promise
     
         // Determine which operation to forward to
         if (operation.insertOne) {
@@ -74,10 +74,8 @@ module.exports = function Collection(db, state) {
           throw Error('bulkWrite only supports insertOne, updateOne, updateMany, deleteOne, deleteMany')
         }
         
-        if (promise) {
-          // Add the operation results to the list
-          promises.push(promise)
-        }
+        // Add the operation results to the list
+        promises.push(promise)
       }
 
       Promise.all(promises).then(function(values) {


### PR DESCRIPTION
Needed this, so wrote an implementation, hopefully it's helpful.

I'm forwarding each bulk write operation to the corresponding method, then aggregating the results.

As of opening this PR `replaceOne` is not implemented, but I see some open PRs for it. Once that method gets a body, `replaceOne` operations provided to a bulk write call should just start working.